### PR TITLE
Authenticated user gets kicked when trying to connect with the same account with wrong credentials

### DIFF
--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -15,6 +15,7 @@ function ClientPacketStatus (client, packet) {
 
 var connectActions = [
   authenticate,
+  registerClient,
   fetchSubs,
   restoreSubs,
   storeWill,
@@ -34,7 +35,7 @@ function handleConnect (client, packet, done) {
   client.id = packet.clientId || uuid.v4()
   client.will = packet.will
 
-  client.broker.registerClient(client)
+  //client.broker.registerClient(client)
 
   clearTimeout(client._connectTimer)
   client._connectTimer = null
@@ -74,6 +75,10 @@ function authenticate (arg, done) {
       }, client.close.bind(client, done))
     }
   }
+}
+
+function registerClient (arg, done) {
+  this.client.broker.registerClient(this.client)
 }
 
 function fetchSubs (arg, done) {


### PR DESCRIPTION
Authenticated user gets kicked when trying to connect another client instance with the same account even with wrong password.