### PR TITLE
Fix require() statement in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install aedes --save
 <a name="example"></a>
 ## Example
 ```js
-var aedes = require('./aedes')()
+var aedes = require('aedes')()
 var server = require('net').createServer(aedes.handle)
 var port = 1883
 


### PR DESCRIPTION
The README.md example code does not run as-is unless the `require('./aedes')` is changed to `require('aedes')` since the module is installed via `npm install aedes --save`.