### PR TITLE
prevent null client unregister

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -75,9 +75,14 @@ function Client (broker, conn) {
   }
 
   this.deliverQoS = function deliverQoS (_packet, cb) {
-    var packet = new QoSPacket(_packet, that)
-    packet.writeCallback = cb
-    broker.persistence.outgoingUpdate(that, packet, writeQoS)
+    //TODO: downgrade to QoS1 if applicable
+    if (_packet.qos == 0){
+      that.deliver0(_packet, cb);
+    } else {
+      var packet = new QoSPacket(_packet, that)
+      packet.writeCallback = cb
+      broker.persistence.outgoingUpdate(that, packet, writeQoS)
+    }
   }
 
   this._keepaliveTimer = null

--- a/lib/client.js
+++ b/lib/client.js
@@ -190,8 +190,6 @@ Client.prototype.close = function (done) {
 
     if (that.broker.clients[that.id]) {
       that.broker.unregisterClient(that)
-    } else {
-      console.log('################# tu bi se dogodila greska')
     }
 
     // hack to clean up the write callbacks

--- a/lib/client.js
+++ b/lib/client.js
@@ -75,9 +75,9 @@ function Client (broker, conn) {
   }
 
   this.deliverQoS = function deliverQoS (_packet, cb) {
-    //TODO: downgrade to QoS1 if applicable
-    if (_packet.qos == 0){
-      that.deliver0(_packet, cb);
+    // downgrade to qos0 if requested by publish
+    if (_packet.qos === 0) {
+      that.deliver0(_packet, cb)
     } else {
       var packet = new QoSPacket(_packet, that)
       packet.writeCallback = cb
@@ -190,6 +190,8 @@ Client.prototype.close = function (done) {
 
     if (that.broker.clients[that.id]) {
       that.broker.unregisterClient(that)
+    } else {
+      console.log('################# tu bi se dogodila greska')
     }
 
     // hack to clean up the write callbacks

--- a/lib/client.js
+++ b/lib/client.js
@@ -183,7 +183,9 @@ Client.prototype.close = function (done) {
     conn.removeAllListeners('error')
     conn.on('error', nop)
 
-    that.broker.unregisterClient(that)
+    if (that.broker.clients[that.id]) {
+      that.broker.unregisterClient(that)
+    }
 
     // hack to clean up the write callbacks
     // supports streams2 & streams3, so node 0.10, 0.11, and iojs

--- a/test/auth.js
+++ b/test/auth.js
@@ -48,7 +48,7 @@ test('authenticate successfully a client with username and password', function (
 })
 
 test('authenticate unsuccessfully a client with username and password', function (t) {
-  t.plan(5)
+  t.plan(6)
 
   var s = setup()
 
@@ -74,6 +74,7 @@ test('authenticate unsuccessfully a client with username and password', function
   })
 
   eos(s.outStream, function () {
+    t.equal(s.broker.connectedClients, 0, 'no connected clients')
     t.pass('ended')
   })
 

--- a/test/qos1.js
+++ b/test/qos1.js
@@ -545,3 +545,29 @@ test('upgrade a QoS 0 subscription to QoS 1', function (t) {
     })
   })
 })
+
+test('downgrade QoS 0 publish on QoS 1 subsciption', function (t) {
+  var s = connect(setup())
+  var expected = {
+    cmd: 'publish',
+    topic: 'hello',
+    payload: new Buffer('world'),
+    qos: 0,
+    length: 12,
+    retain: false,
+    dup: false
+  }
+
+  subscribe(t, s, 'hello', 1, function () {
+    s.outStream.once('data', function (packet) {
+      t.deepEqual(packet, expected, 'packet matches')
+      t.end()
+    })
+    s.broker.publish({
+      cmd: 'publish',
+      topic: 'hello',
+      payload: 'world',
+      qos: 0
+    })
+  })
+})


### PR DESCRIPTION
When using TLS like this:
```
var tlsServer = tls.createServer(options, function(s){  
  console.log('secure connection established');
  aedes.handle(s);
});
tlsServer.listen(config.ports.tcptls);
```
Sometimes happens that client does not connect completely (e.g. using some ssl scan tool like https://github.com/rbsec/sslscan) and **end-of-stream** is firing a callback which is **client.close()**. In that situation, client is not connected to the broker. That causes incorrect decrement of connected clients in broker.unregisterClient()