### PR TITLE
Add options for overriding methods in broker creation

### DIFF
--- a/aedes.js
+++ b/aedes.js
@@ -11,8 +11,19 @@ var Packet = require('aedes-packet')
 var bulk = require('bulk-write-stream')
 var reusify = require('reusify')
 var Client = require('./lib/client')
+var _ = require('lodash')
 
 module.exports = Aedes
+
+var defaultOptions = {
+  concurrency: 100,
+  heartbeatInterval: 60000, // 1 minute
+  connectTimeout: 30000, // 30 secs
+  authenticate: function (client, username, password, callback) { callback(null, true) },
+  authorizePublish: function (client, packet, callback) { callback(null) },
+  authorizeSubscribe: function (client, sub, callback) { callback(null, sub) },
+  published: function (packet, client, callback) { callback(null) }
+}
 
 function Aedes (opts) {
   var that = this
@@ -21,11 +32,7 @@ function Aedes (opts) {
     return new Aedes(opts)
   }
 
-  // TODO replace with extend
-  opts = opts || {}
-  opts.concurrency = opts.concurrency || 100
-  opts.heartbeatInterval = opts.heartbeatInterval || 60000 // 1 minute
-  opts.connectTimeout = opts.connectTimeout || 30000 // 30 secs
+  opts = _.defaults(opts || {}, defaultOptions)
 
   this.id = shortid()
   this.counter = 0
@@ -41,6 +48,11 @@ function Aedes (opts) {
   this._parallel = parallel()
   this._series = series()
   this._enqueuers = reusify(DoEnqueues)
+
+  this.authenticate = opts.authenticate
+  this.authorizePublish = opts.authorizePublish
+  this.authorizeSubscribe = opts.authorizeSubscribe
+  this.published = opts.published
 
   this.clients = {}
   this.brokers = {}
@@ -266,22 +278,6 @@ Aedes.prototype.close = function (cb) {
   clearInterval(this._heartbeatInterval)
   clearInterval(this._clearWillInterval)
   this._parallel(this, closeClient, Object.keys(this.clients), cb || noop)
-}
-
-Aedes.prototype.authenticate = function (client, username, password, callback) {
-  callback(null, true)
-}
-
-Aedes.prototype.authorizePublish = function (client, packet, callback) {
-  callback(null)
-}
-
-Aedes.prototype.authorizeSubscribe = function (client, sub, cb) {
-  cb(null, sub)
-}
-
-Aedes.prototype.published = function (packet, client, done) {
-  done(null)
 }
 
 function PublishState (broker, client, packet) {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "fastparallel": "^2.0.0",
     "fastseries": "^1.5.0",
     "from2": "^2.1.0",
+    "lodash": "^4.5.1",
     "mqemitter": "^1.0.0",
     "mqtt-packet": "^4.0.0",
     "pump": "^1.0.0",


### PR DESCRIPTION
`authenticate`, `authorizePublish`, `authorizeSubscribe`, and `published` methods can be passed in the configuration options when initializing the broker or can be set after the fact as it works now:

```javascript
var aedes = require('aedes')({
  authenticate: function (client, username, password, callback) {
    callback(null, username === 'skroob' && password === '12345')
  }
)};
```

Also refactored the options ab it to use a `defaults` function for clarity.

This addresses https://github.com/mcollina/aedes/issues/9