### PR TITLE
Add 'delivered' event on PUBACK handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ Events:
   1. `packet`
   2. `client`, it will be null if the message is published using
      [`publish`](#publish).
+* `deliver`: when a packet published to a client is delivered successfully, arguments:
+  1. `packet`
+  2. `client`
 * `subscribe`: when a client sends a SUBSCRIBE, arguments:
   1. `subscriptions`, as defined in the `subscriptions` property of the
      [SUBSCRIBE](https://github.com/mqttjs/mqtt-packet#subscribe)

--- a/lib/handlers/puback.js
+++ b/lib/handlers/puback.js
@@ -3,6 +3,7 @@
 function handlePuback (client, packet, done) {
   var persistence = client.broker.persistence
   persistence.outgoingClearMessageId(client, packet, done)
+  client.broker.emit('delivered', packet, client)
 }
 
 module.exports = handlePuback

--- a/lib/handlers/puback.js
+++ b/lib/handlers/puback.js
@@ -3,7 +3,7 @@
 function handlePuback (client, packet, done) {
   var persistence = client.broker.persistence
   persistence.outgoingClearMessageId(client, packet, done)
-  client.broker.emit('delivered', packet, client)
+  client.broker.emit('deliver', packet, client)
 }
 
 module.exports = handlePuback

--- a/test/client-pub-sub.js
+++ b/test/client-pub-sub.js
@@ -115,7 +115,7 @@ test('emit a `deliver` event on PUBCOMP for QoS 2', function (t) {
     client.publish({
       topic: 'hello',
       payload: new Buffer('world'),
-      qos: 1
+      qos: 2
     }, function (err) {
       t.error(err, 'no error')
     })

--- a/test/client-pub-sub.js
+++ b/test/client-pub-sub.js
@@ -73,7 +73,7 @@ test('publish direct to a single client QoS 1', function (t) {
   })
 })
 
-test('emit a `delivered` event on PUBACK for QoS 1', function (t) {
+test('emit a `deliver` event on PUBACK for QoS 1', function (t) {
   t.plan(3)
 
   var broker = aedes()
@@ -89,9 +89,9 @@ test('emit a `delivered` event on PUBACK for QoS 1', function (t) {
     })
   })
 
-  broker.once('delivered', function (packet, client) {
+  broker.once('deliver', function (packet, client) {
     t.equal(packet.messageId, messageId)
-    t.pass('got the delivered event')
+    t.pass('got the deliver event')
   })
 
   var s = connect(setup(broker))


### PR DESCRIPTION
This addresses https://github.com/mcollina/aedes/issues/10 and emits a `delivered` event when a PUBACK is received.