### PR TITLE
Fixed glitch in keepaliveInterval

### DIFF
--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -38,7 +38,7 @@ function handleConnect (client, packet, done) {
   client._connectTimer = null
 
   if (packet.keepalive > 0) {
-    client._keepaliveInterval = packet.keepalive * 1501
+    client._keepaliveInterval = packet.keepalive * 1500 + 1
     client._keepaliveTimer = retimer(function keepaliveTimeout () {
       client.broker.emit('keepaliveTimeout', client)
       client.emit('error', new Error('keep alive timeout'))


### PR DESCRIPTION
It used to: disconnect after 1501 * keepalive time
It now: disconnects after 1500 * keepalive time + 1 millisecond

This solves issues with large keepalive numbers sent with the connect packet.