### PR TITLE
Fix invalid subscription handling

### DIFF
--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -108,7 +108,7 @@ function gotSubs (err, subs, client) {
 
 function restoreSubs (arg, done) {
   if (arg.subs) {
-    handleSubscribe(this.client, { subscriptions: arg.subs }, done)
+    handleSubscribe(this.client, { subscriptions: arg.subs, restore: true }, done)
   } else {
     done()
   }

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -60,19 +60,20 @@ function storeSubscriptions (sub, done) {
   var broker = client.broker
   var perst = broker.persistence
 
-  // if (!packet.messageId) {
-  //   // restore subscriptions
-  //   perst._addedSubscriptions(client, [sub])
-  //   return done(null, sub)
-  // }
-
   if (packet.subscriptions[0].topic !== sub.topic) {
-    // don't call addSubscriptions on each topic
+    // don't call addSubscriptions per topic,
+    // TODO change aedes subscribe handle, but this is a fast & dirty fix for now
+    return done(null, sub)
+  }
+
+  if (!packet.messageId) {
+    // this is a restoreSubscription, don't addSubscriptions!
+    // TODO change aedes subscribe handle, but this is a fast & dirty fix for now
+    perst._addedSubscriptions(client, packet.subscriptions)
     return done(null, sub)
   }
 
   perst.addSubscriptions(client, packet.subscriptions, function (err) {
-    // perst._addedSubscriptions(client, packet.subscriptions)
     done(err, sub)
   })
 }

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -134,19 +134,15 @@ function completeSubscribe (err) {
     done()
   }
 
-  sendRetained()
-
-  function sendRetained () {
-    var persistence = broker.persistence
-    var topics = packet.subscriptions.map(function (s) { return s.topic })
-    var stream = persistence.createRetainedStreamCombi(topics)
-    stream.pipe(through.obj(function sendRetained (packet, enc, cb) {
-      packet = new Packet(packet)
-      // this should not be deduped
-      packet.brokerId = null
-      client.deliver0(packet, cb)
-    }))
-  }
+  var persistence = broker.persistence
+  var topics = packet.subscriptions.map(function (s) { return s.topic })
+  var stream = persistence.createRetainedStreamCombi(topics)
+  stream.pipe(through.obj(function sendRetained (packet, enc, cb) {
+    packet = new Packet(packet)
+    // this should not be deduped
+    packet.brokerId = null
+    client.deliver0(packet, cb)
+  }))
 }
 
 function SubAck (packet, granted) {

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -103,29 +103,13 @@ function subTopic (sub, done) {
 
   if (!client.subscriptions[sub.topic]) {
     client.subscriptions[sub.topic] = new Subscription(sub.qos, func)
-    broker.subscribe(sub.topic, func, sendRetained)
+    broker.subscribe(sub.topic, func, done)
   } else if (client.subscriptions[sub.topic].qos !== sub.qos) {
     broker.unsubscribe(sub.topic, client.subscriptions[sub.topic].func)
     client.subscriptions[sub.topic] = new Subscription(sub.qos, func)
-    broker.subscribe(sub.topic, func, sendRetained)
+    broker.subscribe(sub.topic, func, done)
   } else {
-    sendRetained()
-  }
-
-  function sendRetained () {
-    // first do a suback
     done()
-
-    var persistence = broker.persistence
-
-    var stream = persistence.createRetainedStream(sub.topic)
-
-    stream.pipe(through.obj(function sendRetained (packet, enc, cb) {
-      packet = new Packet(packet)
-      // this should not be deduped
-      packet.brokerId = null
-      client.deliver0(packet, cb)
-    }))
   }
 }
 
@@ -148,6 +132,20 @@ function completeSubscribe (err) {
     write(client, new SubAck(packet, granted), done)
   } else {
     done()
+  }
+
+  sendRetained()
+
+  function sendRetained () {
+    var persistence = broker.persistence
+    var topics = packet.subscriptions.map(function (s) { return s.topic })
+    var stream = persistence.createRetainedStreamCombi(topics)
+    stream.pipe(through.obj(function sendRetained (packet, enc, cb) {
+      packet = new Packet(packet)
+      // this should not be deduped
+      packet.brokerId = null
+      client.deliver0(packet, cb)
+    }))
   }
 }
 

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -22,7 +22,7 @@ function handleSubscribe (client, packet, done) {
   var subs = packet.subscriptions
   var granted = []
 
-  broker._series(
+  broker._parallel(
     new SubscribeState(client, packet, done, granted),
     doSubscribe,
     subs,

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -60,7 +60,7 @@ function storeSubscriptions (sub, done) {
   var broker = client.broker
   var perst = broker.persistence
 
-  if (packet.subscriptions[0].topic !== sub.topic) {
+  if (sub && packet.subscriptions[0].topic !== sub.topic) {
     // don't call addSubscriptions per topic,
     // TODO change aedes subscribe handle, but this is a fast & dirty fix for now
     return done(null, sub)
@@ -69,7 +69,9 @@ function storeSubscriptions (sub, done) {
   if (!packet.messageId) {
     // this is a restoreSubscription, don't addSubscriptions!
     // TODO change aedes subscribe handle, but this is a fast & dirty fix for now
-    perst._addedSubscriptions(client, packet.subscriptions)
+    if (perst._addedSubscriptions) {
+      perst._addedSubscriptions(client, packet.subscriptions)
+    }
     return done(null, sub)
   }
 

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -60,7 +60,19 @@ function storeSubscriptions (sub, done) {
   var broker = client.broker
   var perst = broker.persistence
 
+  if (!packet.messageId) {
+    // restore subscriptions
+    perst._addedSubscriptions(client, [sub])
+    return done(null, sub)
+  }
+
+  if (packet.subscriptions[0].topic !== sub.topic) {
+    // don't call addSubscriptions on each topic
+    return done(null, sub)
+  }
+
   perst.addSubscriptions(client, packet.subscriptions, function (err) {
+    perst._addedSubscriptions(client, [sub])
     done(err, sub)
   })
 }
@@ -130,9 +142,8 @@ function completeSubscribe (err) {
     return done(err)
   }
 
-  broker.emit('subscribe', packet.subscriptions, client)
-
   if (packet.messageId) {
+    broker.emit('subscribe', packet.subscriptions, client)
     write(client, new SubAck(packet, granted), done)
   } else {
     done()

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -66,9 +66,7 @@ function storeSubscriptions (sub, done) {
     return done(null, sub)
   }
 
-  if (!packet.messageId) {
-    // this is a restoreSubscription, don't addSubscriptions!
-    // TODO change aedes subscribe handle, but this is a fast & dirty fix for now
+  if (packet.restore) {
     return done(null, sub)
   }
 

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -60,11 +60,11 @@ function storeSubscriptions (sub, done) {
   var broker = client.broker
   var perst = broker.persistence
 
-  if (!packet.messageId) {
-    // restore subscriptions
-    perst._addedSubscriptions(client, [sub])
-    return done(null, sub)
-  }
+  // if (!packet.messageId) {
+  //   // restore subscriptions
+  //   perst._addedSubscriptions(client, [sub])
+  //   return done(null, sub)
+  // }
 
   if (packet.subscriptions[0].topic !== sub.topic) {
     // don't call addSubscriptions on each topic
@@ -72,7 +72,7 @@ function storeSubscriptions (sub, done) {
   }
 
   perst.addSubscriptions(client, packet.subscriptions, function (err) {
-    perst._addedSubscriptions(client, [sub])
+    // perst._addedSubscriptions(client, packet.subscriptions)
     done(err, sub)
   })
 }

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -69,9 +69,6 @@ function storeSubscriptions (sub, done) {
   if (!packet.messageId) {
     // this is a restoreSubscription, don't addSubscriptions!
     // TODO change aedes subscribe handle, but this is a fast & dirty fix for now
-    if (perst._addedSubscriptions) {
-      perst._addedSubscriptions(client, packet.subscriptions)
-    }
     return done(null, sub)
   }
 

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -140,8 +140,11 @@ function completeSubscribe (err) {
     return done(err)
   }
 
-  if (packet.messageId) {
+  if (!packet.restore) {
     broker.emit('subscribe', packet.subscriptions, client)
+  }
+
+  if (packet.messageId) {
     write(client, new SubAck(packet, granted), done)
   } else {
     done()

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -135,7 +135,10 @@ function completeSubscribe (err) {
   }
 
   var persistence = broker.persistence
-  var topics = packet.subscriptions.map(function (s) { return s.topic })
+  var topics = []
+  for (var i = 0; i < packet.subscriptions.length; i++) {
+    topics.push(packet.subscriptions[i].topic)
+  }
   var stream = persistence.createRetainedStreamCombi(topics)
   stream.pipe(through.obj(function sendRetained (packet, enc, cb) {
     packet = new Packet(packet)

--- a/lib/handlers/unsubscribe.js
+++ b/lib/handlers/unsubscribe.js
@@ -27,7 +27,7 @@ function handleUnsubscribe (client, packet, done) {
 
 function actualUnsubscribe (client, packet, done) {
   var broker = client.broker
-  broker._series(
+  broker._parallel(
     new UnsubscribeState(client, packet, done, null),
     doUnsubscribe,
     packet.unsubscriptions,

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "aedes-packet": "^1.0.0",
-    "aedes-persistence": "^3.0.0",
+    "aedes-persistence": "^4.0.0",
     "bulk-write-stream": "^1.0.0",
     "end-of-stream": "^1.1.0",
     "fastfall": "^1.0.0",


### PR DESCRIPTION
1. Fix `addSubscriptions` being called per topic, it should be called once for the topics array as said in README

2. Fix `addSubscriptions` being called when restoring client subs, it this case aedes-cached-`persistence#addedSubscriptions` should only be called.

3. Don't emit subscribe on restoring client subs.

fix number 1 and 2 are fast & dirty, but that not bad.
A better fix would need 

- changing the whole handleSubscribe, not to call `storeSubscriptions` per topic
- introducing a `restoreSubscriptions` method
- moving up (and renaming for a better one) `addedSubscriptions` up into aedes subscribe handler, I don't think [this](https://github.com/mcollina/aedes-cached-persistence/blob/master/index.js#L79-L93) is a implementation that should be inside aedes-cached-persistence

however these require a total refactoring in all persistence implementations, Some should help for such a change.