### PR TITLE
clean clients should not have persistent subscription records.

### DIFF
--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -75,6 +75,10 @@ function storeSubscriptions (sub, done) {
     return done(null, sub)
   }
 
+  if (client.clean) {
+    return done(null, sub)
+  }
+
   perst.addSubscriptions(client, packet.subscriptions, function (err) {
     done(err, sub)
   })


### PR DESCRIPTION
If the current client is a clean session, a subscription should not be stored in persistence as it is not a persistent session.