### PR TITLE
Just for review -)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ flamegraph.html
 .__*
 profile*
 
+.idea
+.DS_Store
+dump.rdb
+

--- a/lib/agents/IPCClient.js
+++ b/lib/agents/IPCClient.js
@@ -1,0 +1,87 @@
+
+var config = {
+  appspace: 'app.',
+  socketRoot: '/tmp/',
+  networkHost: 'localhost', // should resolve to 127.0.0.1 or ::1 see the table below related to this
+  networkPort: 9200,
+  encoding: 'utf8',
+  rawBuffer: false,
+  sync: false,
+  silent: false,
+  logInColor: true,
+  logDepth: 5,
+  retry: 500,
+  maxRetries: false,
+  stopRetrying: false
+}
+
+function extend (target) {
+  var sources = [].slice.call(arguments, 1)
+  sources.forEach(function (source) {
+    for (var prop in source) {
+      target[prop] = source[prop]
+    }
+  })
+  return target
+}
+
+function IPCClient () {
+  this.ipc = require('node-ipc')
+  console.log('IPC Client Constructor')
+  extend(this.ipc.config, config)
+}
+
+IPCClient.prototype.connect = createIPCInstance
+
+function createIPCInstance (configObject, target, dataCallback) {
+  var that = this
+  return new Promise(function (resolve, reject) {
+    // var that = this
+
+    if (!configObject.id) {
+      throw new Error('Id is required')
+    } else {
+      extend(that.ipc.config, configObject)
+    }
+    that.ipc.connectTo(
+      target,
+      function () {
+        that.ipc.of[target].on(
+          'connect',
+          function () {
+            that.ipc.log('connected to server: ' + target, that.ipc.config.delay)
+            /*
+            ipc.of[target].emit(
+              'hello from client :)'
+            )
+            */
+            resolve(that.ipc.of[target])
+          }
+        )
+        that.ipc.of[target].on(
+          'error',
+          function (err) {
+            that.ipc.log('## error:', err)
+            reject(err)
+          }
+        )
+        that.ipc.of[target].on(
+          'disconnect',
+          function () {
+            that.ipc.log('## Disconnected from server ##')
+          }
+        )
+        if (dataCallback) {
+          that.ipc.of[target].on(
+            'data',
+            dataCallback
+          )
+        }
+      }
+    )
+  })
+}
+
+module.exports = function () {
+  return new IPCClient()
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aedes",
-  "version": "0.29.3",
+  "version": "0.30.0",
   "description": "Stream-based MQTT broker",
   "main": "aedes.js",
   "scripts": {
@@ -39,7 +39,7 @@
     "duplexify": "^3.5.1",
     "faucet": "0.0.1",
     "istanbul": "^0.4.1",
-    "mqtt": "^2.11.0",
+    "mqtt": "^2.12.0",
     "mqtt-connection": "^3.0.0",
     "pre-commit": "^1.0.10",
     "standard": "^10.0.3",
@@ -55,7 +55,7 @@
     "fastparallel": "^2.0.0",
     "fastseries": "^1.5.0",
     "from2": "^2.1.0",
-    "mqemitter": "^2.1.0",
+    "mqemitter": "^2.2.0",
     "mqtt-packet": "^5.4.0",
     "pump": "^1.0.0",
     "retimer": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "from2": "^2.1.0",
     "mqemitter": "^2.2.0",
     "mqtt-packet": "^5.4.0",
+    "node-ipc": "^9.1.1",
     "pump": "^1.0.0",
     "retimer": "^1.0.0",
     "reusify": "^1.0.2",

--- a/test/basic.js
+++ b/test/basic.js
@@ -163,7 +163,7 @@ test('live retain packets', function (t) {
     cmd: 'publish',
     topic: 'hello',
     payload: Buffer.from('world'),
-    retain: false,
+    retain: true,
     dup: false,
     length: 12,
     qos: 0

--- a/test/qos1.js
+++ b/test/qos1.js
@@ -427,7 +427,7 @@ test('deliver QoS 1 retained messages', function (t) {
     qos: 1,
     dup: false,
     length: 14,
-    retain: false
+    retain: true
   }
 
   subscribe(t, subscriber, 'hello', 1, function () {


### PR DESCRIPTION
@mcollina 
This is pull request for review and related to our latest discussion.

Changed the tests to allow emitting('publish') with original retained flag (set by user when publishing, or broker when sending retained messages)

I've also added what is called an IPCClient - which is for our internal usages
and perhaps does not have place inside Aedes, probably should be thought of a bit more to conform into the Aedes eco-ssystem.

The IPCClient uses local socket to connect to an IPC process which is keeping
track of all connected / disconnected client from each process.

so in the case of an architecture having 10 nodejs processess each running an Aedes server,
the IPC will know which client is online and which is not.

the other parts of the IPC are the Near gateway and far gateway, both are part of a module called ClusterLink.

Again, this is all part of our development, and would love perhaps to see Aedes
grow into a Clustered solution for MQTT.
