### PR TITLE
Fix for Retained message still delivered on negated subscription 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach",
+      "port": 9229
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "program": "${workspaceFolder}/persistence-example.js"
+    }
+  ]
+}

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -1,175 +1,183 @@
-'use strict'
+"use strict";
 
-var write = require('../write')
-var fastfall = require('fastfall')
-var Packet = require('aedes-packet')
-var through = require('through2')
-var validateTopic = require('./validations').validateTopic
-var topicActions = fastfall([
-  authorize,
-  storeSubscriptions,
-  subTopic
-])
+var write = require("../write");
+var fastfall = require("fastfall");
+var Packet = require("aedes-packet");
+var through = require("through2");
+var validateTopic = require("./validations").validateTopic;
+var topicActions = fastfall([authorize, storeSubscriptions, subTopic]);
 
-function SubscribeState (client, packet, finish, granted) {
-  this.client = client
-  this.packet = packet
-  this.finish = finish
-  this.granted = granted
+function SubscribeState(client, packet, finish, granted) {
+  this.client = client;
+  this.packet = packet;
+  this.finish = finish;
+  this.granted = granted;
 }
 
-function handleSubscribe (client, packet, done) {
-  var broker = client.broker
-  var subs = packet.subscriptions
-  var granted = []
+function handleSubscribe(client, packet, done) {
+  var broker = client.broker;
+  var subs = packet.subscriptions;
+  var granted = [];
 
   broker._series(
     new SubscribeState(client, packet, done, granted),
     doSubscribe,
     subs,
-    completeSubscribe)
+    completeSubscribe
+  );
 }
 
-function doSubscribe (sub, done) {
+function doSubscribe(sub, done) {
   // TODO this function should not be needed
-  topicActions.call(this, sub, done)
+  topicActions.call(this, sub, done);
 }
 
-function authorize (sub, done) {
-  var client = this.client
-  var err = validateTopic(sub.topic, 'SUBSCRIBE')
+function authorize(sub, done) {
+  var client = this.client;
+  var err = validateTopic(sub.topic, "SUBSCRIBE");
   if (err) {
-    return done(err)
+    return done(err);
   }
-  client.broker.authorizeSubscribe(client, sub, done)
+  client.broker.authorizeSubscribe(client, sub, done);
 }
 
-function blockSys (func) {
-  return function deliverSharp (packet, cb) {
-    if (packet.topic.indexOf('$SYS') === 0) {
-      cb()
+function blockSys(func) {
+  return function deliverSharp(packet, cb) {
+    if (packet.topic.indexOf("$SYS") === 0) {
+      cb();
     } else {
-      func(packet, cb)
+      func(packet, cb);
     }
+  };
+}
+
+function Subscription(qos, func) {
+  this.qos = qos;
+  this.func = func;
+}
+
+function storeSubscriptions(sub, done) {
+  var packet = this.packet;
+  var client = this.client;
+  var broker = client.broker;
+  var perst = broker.persistence;
+
+  // total hack. Love it. Good enough for government work.  Probably should be redone with that TODO down there...
+  if (!sub) {
+    client.isAuthorizedForSub = false;
+  } else {
+    client.isAuthorizedForSub = true;
   }
-}
-
-function Subscription (qos, func) {
-  this.qos = qos
-  this.func = func
-}
-
-function storeSubscriptions (sub, done) {
-  var packet = this.packet
-  var client = this.client
-  var broker = client.broker
-  var perst = broker.persistence
 
   if (sub && packet.subscriptions[0].topic !== sub.topic) {
     // don't call addSubscriptions per topic,
     // TODO change aedes subscribe handle, but this is a fast & dirty fix for now
-    return done(null, sub)
+    return done(null, sub);
   }
 
   if (packet.restore) {
-    return done(null, sub)
+    return done(null, sub);
   }
 
   if (client.clean) {
-    return done(null, sub)
+    return done(null, sub);
   }
 
-  perst.addSubscriptions(client, packet.subscriptions, function (err) {
-    done(err, sub)
-  })
+  perst.addSubscriptions(client, packet.subscriptions, function(err) {
+    done(err, sub);
+  });
 }
 
-function subTopic (sub, done) {
+function subTopic(sub, done) {
   if (!sub) {
-    this.granted.push(128)
-    return done()
+    this.granted.push(128);
+    return done();
   }
 
-  var client = this.client
-  var broker = client.broker
-  var func = nop
+  var client = this.client;
+  var broker = client.broker;
+  var func = nop;
 
   switch (sub.qos) {
     case 2:
     case 1:
-      func = client.deliverQoS
-      break
+      func = client.deliverQoS;
+      break;
     default:
-      func = client.deliver0
-      break
+      func = client.deliver0;
+      break;
   }
 
   if (isWildcardThatMatchesSys(sub.topic)) {
-    func = blockSys(func)
+    func = blockSys(func);
   }
 
-  this.granted.push(sub.qos)
+  this.granted.push(sub.qos);
 
   if (!client.subscriptions[sub.topic]) {
-    client.subscriptions[sub.topic] = new Subscription(sub.qos, func)
-    broker.subscribe(sub.topic, func, done)
+    client.subscriptions[sub.topic] = new Subscription(sub.qos, func);
+    broker.subscribe(sub.topic, func, done);
   } else if (client.subscriptions[sub.topic].qos !== sub.qos) {
-    broker.unsubscribe(sub.topic, client.subscriptions[sub.topic].func)
-    client.subscriptions[sub.topic] = new Subscription(sub.qos, func)
-    broker.subscribe(sub.topic, func, done)
+    broker.unsubscribe(sub.topic, client.subscriptions[sub.topic].func);
+    client.subscriptions[sub.topic] = new Subscription(sub.qos, func);
+    broker.subscribe(sub.topic, func, done);
   } else {
-    done()
+    done();
   }
 }
 
 // + is 43
 // # is 35
-function isWildcardThatMatchesSys (topic) {
-  var code = topic.charCodeAt(0)
-  return code === 43 || code === 35
+function isWildcardThatMatchesSys(topic) {
+  var code = topic.charCodeAt(0);
+  return code === 43 || code === 35;
 }
 
-function completeSubscribe (err) {
-  var packet = this.packet
-  var client = this.client
-  var broker = client.broker
-  var granted = this.granted
-  var done = this.finish
+function completeSubscribe(err) {
+  var packet = this.packet;
+  var client = this.client;
+  var broker = client.broker;
+  var granted = this.granted;
+  var done = this.finish;
 
   if (err) {
-    return done(err)
+    return done(err);
   }
 
   if (!packet.restore) {
-    broker.emit('subscribe', packet.subscriptions, client)
+    broker.emit("subscribe", packet.subscriptions, client);
   }
 
   if (packet.messageId) {
-    write(client, new SubAck(packet, granted), done)
+    write(client, new SubAck(packet, granted), done);
   } else {
-    done()
+    done();
   }
 
-  var persistence = broker.persistence
-  var topics = []
+  var persistence = broker.persistence;
+  var topics = [];
   for (var i = 0; i < packet.subscriptions.length; i++) {
-    topics.push(packet.subscriptions[i].topic)
+    topics.push(packet.subscriptions[i].topic);
   }
-  var stream = persistence.createRetainedStreamCombi(topics)
-  stream.pipe(through.obj(function sendRetained (packet, enc, cb) {
-    packet = new Packet(packet)
-    // this should not be deduped
-    packet.brokerId = null
-    client.deliver0(packet, cb)
-  }))
+  var stream = persistence.createRetainedStreamCombi(topics);
+  stream.pipe(
+    through.obj(function sendRetained(packet, enc, cb) {
+      packet = new Packet(packet);
+      // this should not be deduped
+      packet.brokerId = null;
+      if (client.isAuthorizedForSub) {
+        client.deliver0(packet, cb);
+      }
+    })
+  );
 }
 
-function SubAck (packet, granted) {
-  this.cmd = 'suback'
-  this.messageId = packet.messageId
-  this.granted = granted
+function SubAck(packet, granted) {
+  this.cmd = "suback";
+  this.messageId = packet.messageId;
+  this.granted = granted;
 }
 
-function nop () {}
+function nop() {}
 
-module.exports = handleSubscribe
+module.exports = handleSubscribe;

--- a/persistence-example.js
+++ b/persistence-example.js
@@ -1,0 +1,59 @@
+"use strict";
+
+var persistence = require("aedes-persistence");
+var aedes = require("./aedes")({
+  persistence: persistence()
+});
+
+var server = require("net").createServer(aedes.handle);
+var httpServer = require("http").createServer();
+var ws = require("websocket-stream");
+var port = 1883;
+var wsPort = 8888;
+
+aedes.authorizeSubscribe = function(client, sub, cb) {
+  if (sub.topic === "hello/5") {
+    return cb(null, sub);
+  } else {
+    cb(null, null);
+  }
+};
+
+server.listen(port, function() {
+  console.log("server listening on port", port);
+});
+
+ws.createServer(
+  {
+    server: httpServer
+  },
+  aedes.handle
+);
+
+httpServer.listen(wsPort, function() {
+  console.log("websocket server listening on port", wsPort);
+});
+
+aedes.on("clientError", function(client, err) {
+  console.log("client error", client.id, err.message, err.stack);
+});
+
+aedes.on("connectionError", function(client, err) {
+  console.log("client error", client, err.message, err.stack);
+});
+
+aedes.on("publish", function(packet, client) {
+  if (client) {
+    console.log("message from client", client.id);
+  }
+});
+
+aedes.on("subscribe", function(subscriptions, client) {
+  if (client) {
+    console.log("subscribe from client", subscriptions, client.id);
+  }
+});
+
+aedes.on("client", function(client) {
+  console.log("new client", client.id);
+});


### PR DESCRIPTION
Attempts to address #200 

I did not attempt to address the TODO [here](https://github.com/mcollina/aedes/blob/master/lib/handlers/subscribe.js#L34), and to really do this right, it appears as though we should likely address that first (not sure if they are connected to my simple hack fix, but from a cursory look, it appears as though my fix would (should?) be upended with that TODO completion).  Time is not on my side, so I did not attempt to reorganize that TODO.

I half-assed the tests (meaning I did not add any to cover this case).  Technically, from coverage purity perspective, there is still coverage for this, but not sure how we would want to test for retained functionality given the separate abstraction of the persistence plugins.  Open to suggestions here.

