### PR TITLE
Improve Typescript typings to allow explicit typing

### DIFF
--- a/aedes.js
+++ b/aedes.js
@@ -15,6 +15,7 @@ var Client = require('./lib/client')
 var xtend = require('xtend')
 
 module.exports = Aedes
+Aedes.Server = Aedes
 
 var defaultOptions = {
   concurrency: 100,

--- a/test/typescript/typings.ts
+++ b/test/typescript/typings.ts
@@ -1,11 +1,10 @@
 // relative path uses package.json {"types":"types/index.d.ts", ...}
 
-import aedes = require ('../..')
-import { Client, AuthenticateError } from '../..'
+import { Server, Client, AuthenticateError } from '../..'
 import { IPublishPacket, ISubscribePacket, ISubscription, IUnsubscribePacket } from 'mqtt-packet'
 import { createServer } from 'net'
 
-const broker = aedes({
+const broker = Server({
   concurrency: 100,
   heartbeatInterval: 60000,
   connectTimeout: 30000,

--- a/test/typescript/typings.ts
+++ b/test/typescript/typings.ts
@@ -1,24 +1,25 @@
 // relative path uses package.json {"types":"types/index.d.ts", ...}
 
-import Aedes = require ('../..')
+import aedes = require ('../..')
+import { Client, AuthenticateError } from '../..'
 import { IPublishPacket, ISubscribePacket, ISubscription, IUnsubscribePacket } from 'mqtt-packet'
 import { createServer } from 'net'
 
-const aedes = Aedes({
+const broker = aedes({
   concurrency: 100,
   heartbeatInterval: 60000,
   connectTimeout: 30000,
-  authenticate: (client, username: string, password: string, callback) => {
+  authenticate: (client: Client, username: string, password: string, callback) => {
     if (username === 'test' && password === 'test') {
       callback(null, true)
     } else {
-      const error = new Error() as Error & { returnCode: number }
+      const error = new Error() as AuthenticateError
       error.returnCode = 1
 
       callback(error, false)
     }
   },
-  authorizePublish: (client, packet: IPublishPacket, callback) => {
+  authorizePublish: (client: Client, packet: IPublishPacket, callback) => {
     if (packet.topic === 'aaaa') {
       return callback(new Error('wrong topic'))
     }
@@ -29,7 +30,7 @@ const aedes = Aedes({
 
     callback(null)
   },
-  authorizeSubscribe: (client, sub: ISubscription, callback) => {
+  authorizeSubscribe: (client: Client, sub: ISubscription, callback) => {
     if (sub.topic === 'aaaa') {
       return callback(new Error('wrong topic'))
     }
@@ -57,57 +58,57 @@ const aedes = Aedes({
   }
 })
 
-const server = createServer(aedes.handle)
+const server = createServer(broker.handle)
 
-aedes.on('closed', () => {
+broker.on('closed', () => {
   console.log(`closed`)
 })
 
-aedes.on('client', client => {
+broker.on('client', client => {
   console.log(`client: ${client.id} connected`)
 })
 
-aedes.on('clientDisconnect', client => {
+broker.on('clientDisconnect', client => {
   console.log(`client: ${client.id} disconnected`)
 })
 
-aedes.on('keepaliveTimeout', client => {
+broker.on('keepaliveTimeout', client => {
   console.log(`client: ${client.id} timed out`)
 })
 
-aedes.on('connackSent', client => {
+broker.on('connackSent', client => {
   console.log(`client: ${client.id} connack sent`)
 })
 
-aedes.on('clientError', client => {
+broker.on('clientError', client => {
   console.log(`client: ${client.id} error`)
 })
 
-aedes.on('connectionError', client => {
+broker.on('connectionError', client => {
   console.log('connectionError')
 })
 
-aedes.on('ping', (packet, client) => {
+broker.on('ping', (packet, client) => {
   console.log(`client: ${client.id} ping with packet ${packet.id}`)
 })
 
-aedes.on('publish', (packet, client) => {
+broker.on('publish', (packet, client) => {
   console.log(`client: ${client.id} published packet ${packet.id}`)
 })
 
-aedes.on('ack', (packet, client) => {
+broker.on('ack', (packet, client) => {
   console.log(`client: ${client.id} ack with packet ${packet.id}`)
 })
 
-aedes.on('subscribe', (subscriptions, client) => {
+broker.on('subscribe', (subscriptions, client) => {
   console.log(`client: ${client.id} subsribe`)
 })
 
-aedes.on('unsubscribe', (subscriptions, client) => {
+broker.on('unsubscribe', (subscriptions, client) => {
   console.log(`client: ${client.id} subsribe`)
 })
 
-aedes.subscribe('aaaa', (packet: ISubscribePacket, cb) => {
+broker.subscribe('aaaa', (packet: ISubscribePacket, cb) => {
   console.log('cmd')
   console.log(packet.subscriptions)
   cb()
@@ -115,7 +116,7 @@ aedes.subscribe('aaaa', (packet: ISubscribePacket, cb) => {
   console.log('done subscribing')
 })
 
-aedes.unsubscribe('aaaa', (packet: IUnsubscribePacket, cb) => {
+broker.unsubscribe('aaaa', (packet: IUnsubscribePacket, cb) => {
   console.log('cmd')
   console.log(packet.unsubscriptions)
   cb()
@@ -123,4 +124,4 @@ aedes.unsubscribe('aaaa', (packet: IUnsubscribePacket, cb) => {
   console.log('done unsubscribing')
 })
 
-aedes.close()
+broker.close()

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,81 +4,85 @@ import { IPublishPacket, ISubscribePacket, ISubscription, IUnsubscribePacket } f
 import { Duplex } from 'stream'
 import EventEmitter = NodeJS.EventEmitter
 
-declare enum AuthErrorCode {
-  UNNACCEPTABLE_PROTOCOL = 1,
-  IDENTIFIER_REJECTED = 2,
-  SERVER_UNAVAILABLE = 3,
-  BAD_USERNAME_OR_PASSWORD = 4
+declare namespace aedes {
+  export enum AuthErrorCode {
+    UNNACCEPTABLE_PROTOCOL = 1,
+    IDENTIFIER_REJECTED = 2,
+    SERVER_UNAVAILABLE = 3,
+    BAD_USERNAME_OR_PASSWORD = 4
+  }
+
+  export interface Client extends EventEmitter {
+    id: string
+    clean: boolean
+
+    on (event: 'error', cb: (err: Error) => void): this
+
+    publish (message: IPublishPacket, callback?: () => void): void
+    subscribe (
+      subscriptions: ISubscription | ISubscription[] | ISubscribePacket,
+      callback?: () => void
+    ): void
+    unsubscribe (topicObjects: ISubscription | ISubscription[], callback?: () => void): void
+    close (callback?: () => void): void
+  }
+
+  export type AuthenticateError = Error & { returnCode: AuthErrorCode }
+
+  export type AuthenticateCallback = (
+    client: Client,
+    username: string,
+    password: string,
+    done: (err: AuthenticateError | null, success: boolean | null) => void
+  ) => void
+
+  export type AuthorizePublishCallback = (client: Client, packet: IPublishPacket, done: (err?: Error | null) => void) => void
+
+  export type AuthorizeSubscribeCallback = (client: Client, subscription: ISubscription, done: (err: Error | null, subscription?: ISubscription | null) => void) => void
+
+  export type AuthorizeForwardCallback = (client: Client, packet: IPublishPacket) => IPublishPacket | null | void
+
+  export type PublishedCallback = (packet: IPublishPacket, client: Client, done: () => void) => void
+
+  export interface AedesOptions {
+    mq?: any
+    persistence?: any
+    concurrency?: number
+    heartbeatInterval?: number
+    connectTimeout?: number
+    authenticate?: AuthenticateCallback
+    authorizePublish?: AuthorizePublishCallback
+    authorizeSubscribe?: AuthorizeSubscribeCallback
+    authorizeForward?: AuthorizeForwardCallback
+    published?: PublishedCallback
+  }
+
+  export interface Aedes extends EventEmitter {
+    handle: (stream: Duplex) => void
+
+    authenticate: AuthenticateCallback
+    authorizePublish: AuthorizePublishCallback
+    authorizeSubscribe: AuthorizeSubscribeCallback
+    authorizeForward: AuthorizeForwardCallback
+    published: PublishedCallback
+
+    on (event: 'closed', cb: () => void): this
+    on (event: 'client' | 'clientDisconnect' | 'keepaliveTimeout' | 'connackSent', cb: (client: Client) => void): this
+    on (event: 'clientError' | 'connectionError', cb: (client: Client, error: Error) => void): this
+    on (event: 'ping' | 'publish' | 'ack', cb: (packet: any, client: Client) => void): this
+    on (event: 'subscribe' | 'unsubscribe', cb: (subscriptions: ISubscription | ISubscription[] | ISubscribePacket, client: Client) => void): this
+
+    publish (packet: IPublishPacket & { topic: string | Buffer }, done: () => void): void
+    subscribe (topic: string, callback: (packet: ISubscribePacket, cb: () => void) => void, done: () => void): void
+    unsubscribe (
+      topic: string,
+      callback: (packet: IUnsubscribePacket, cb: () => void) => void,
+      done: () => void
+    ): void
+    close (callback?: () => void): void
+  }
 }
 
-interface Client extends EventEmitter {
-  id: string
-  clean: boolean
-
-  on (event: 'error', cb: (err: Error) => void): this
-
-  publish (message: IPublishPacket, callback?: () => void): void
-  subscribe (
-    subscriptions: ISubscription | ISubscription[] | ISubscribePacket,
-    callback?: () => void
-  ): void
-  unsubscribe (topicObjects: ISubscription | ISubscription[], callback?: () => void): void
-  close (callback?: () => void): void
-}
-
-type AuthenticateCallback = (
-  client: Client,
-  username: string,
-  password: string,
-  done: (err: Error & { returnCode: AuthErrorCode } | null, success: boolean | null) => void
-) => void
-
-type AuthorizePublishCallback = (client: Client, packet: IPublishPacket, done: (err?: Error | null) => void) => void
-
-type AuthorizeSubscribeCallback = (client: Client, subscription: ISubscription, done: (err: Error | null, subscription?: ISubscription | null) => void) => void
-
-type AuthorizeForwardCallback = (client: Client, packet: IPublishPacket) => IPublishPacket | null | void
-
-type PublishedCallback = (packet: IPublishPacket, client: Client, done: () => void) => void
-
-interface AedesOptions {
-  mq?: any
-  persistence?: any
-  concurrency?: number
-  heartbeatInterval?: number
-  connectTimeout?: number
-  authenticate?: AuthenticateCallback
-  authorizePublish?: AuthorizePublishCallback
-  authorizeSubscribe?: AuthorizeSubscribeCallback
-  authorizeForward?: AuthorizeForwardCallback
-  published?: PublishedCallback
-}
-
-interface Aedes extends EventEmitter {
-  handle: (stream: Duplex) => void
-
-  authenticate: AuthenticateCallback
-  authorizePublish: AuthorizePublishCallback
-  authorizeSubscribe: AuthorizeSubscribeCallback
-  authorizeForward: AuthorizeForwardCallback
-  published: PublishedCallback
-
-  on (event: 'closed', cb: () => void): this
-  on (event: 'client' | 'clientDisconnect' | 'keepaliveTimeout' | 'connackSent', cb: (client: Client) => void): this
-  on (event: 'clientError' | 'connectionError', cb: (client: Client, error: Error) => void): this
-  on (event: 'ping' | 'publish' | 'ack', cb: (packet: any, client: Client) => void): this
-  on (event: 'subscribe' | 'unsubscribe', cb: (subscriptions: ISubscription | ISubscription[] | ISubscribePacket, client: Client) => void): this
-
-  publish (packet: IPublishPacket & { topic: string | Buffer }, done: () => void): void
-  subscribe (topic: string, callback: (packet: ISubscribePacket, cb: () => void) => void, done: () => void): void
-  unsubscribe (
-    topic: string,
-    callback: (packet: IUnsubscribePacket, cb: () => void) => void,
-    done: () => void
-  ): void
-  close (callback?: () => void): void
-}
-
-declare function aedes (options?: AedesOptions): Aedes
+declare function aedes (options?: aedes.AedesOptions): aedes.Aedes
 
 export = aedes

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -81,6 +81,8 @@ declare namespace aedes {
     ): void
     close (callback?: () => void): void
   }
+
+  export function Server (options?: aedes.AedesOptions): aedes.Aedes
 }
 
 declare function aedes (options?: aedes.AedesOptions): aedes.Aedes


### PR DESCRIPTION
With current type definitions it's not possible to use explicit typing. I changed them based on [this template](https://github.com/Microsoft/TypeScript-Handbook/blob/master/pages/declaration%20files/templates/module-function.d.ts.md) to allow to import all defined types.

Besides that, I added an `AuthenticateError` type and changed typescript tests to use explicit typing in a few places. I also changed some names in tests file to avoid naming collisions and to be more in line with other tests.

Not being able to use explicit typing is a problem in my project, so I hope you will find these changes useful.