### PR TITLE
allow broker id in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Options:
   `60000` milliseconds
 * `connectTimeout`: the max number of milliseconds to wait for the CONNECT
   packet to arrive, defaults to `30000` milliseconds
+* `id`: id used to identify this broker instance in `$SYS` messages,
+  defaults to `shortid()`
 * `authenticate`: function used to authenticate clients, see
   [instance.authenticate()](#authenticate)
 * `authorizePublish`: function used to authorize PUBLISH packets, see

--- a/aedes.js
+++ b/aedes.js
@@ -36,7 +36,7 @@ function Aedes (opts) {
 
   opts = xtend(defaultOptions, opts)
 
-  this.id = shortid()
+  this.id = opts.id || shortid()
   this.counter = 0
   this.connectTimeout = opts.connectTimeout
   this.mq = opts.mq || mqemitter(opts)

--- a/test/basic.js
+++ b/test/basic.js
@@ -714,3 +714,15 @@ test('clear drain', function (t) {
     s.conn.destroy()
   })
 })
+
+test('id option', function (t) {
+  t.plan(2)
+
+  var broker1 = aedes()
+  setup(broker1)
+  t.ok(broker1.id, 'broker gets random id when id option not set')
+
+  var broker2 = aedes({ id: 'abc' })
+  setup(broker2)
+  t.equal(broker2.id, 'abc', 'broker id equals id option when set')
+})


### PR DESCRIPTION
This allows `id` as an option when constructing a broker. When not defined, defaults to the old default of `shortid()`.