### PR TITLE
callback instead of return in authorizeForward 

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,17 +286,16 @@ It will be called when a client is set to recieve a message. Override to supply 
 authorization logic.
 
 ```js
-instance.authorizeForward = function (client, packet) {
+instance.authorizeForward = function (client, packet, callback) {
   if (packet.topic === 'aaaa' && client.id === "I should not see this") {
-    return null
-    // also works with return undefined
+    callback()
   }
 
   if (packet.topic === 'bbb') {
     packet.payload = new Buffer('overwrite packet payload')
   }
 
-  return packet
+  callback(packet)
 }
 ```
 

--- a/aedes.js
+++ b/aedes.js
@@ -303,8 +303,8 @@ function defaultAuthorizeSubscribe (client, sub, callback) {
   callback(null, sub)
 }
 
-function defaultAuthorizeForward (client, packet) {
-  return packet
+function defaultAuthorizeForward (client, packet, callback) {
+  callback(packet)
 }
 
 function defaultPublished (packet, client, callback) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -95,12 +95,17 @@ function Client (broker, conn) {
   }
 
   this.deliver0 = function deliverQoS0 (_packet, cb) {
-    var toForward = dedupe(_packet) &&
-      that.broker.authorizeForward(that, _packet)
+    var toForward = dedupe(_packet)
     if (toForward) {
-      var packet = new Packet(toForward, broker)
-      packet.qos = 0
-      write(that, packet, cb)
+      that.broker.authorizeForward(that, _packet, function (fwdPacket) {
+        if (fwdPacket) {
+          var packet = new Packet(fwdPacket, broker)
+          packet.qos = 0
+          write(that, packet, cb)
+        } else {
+          cb()
+        }
+      })
     } else {
       cb()
     }
@@ -111,16 +116,26 @@ function Client (broker, conn) {
     if (_packet.qos === 0) {
       that.deliver0(_packet, cb)
     } else {
-      var toForward = dedupe(_packet) &&
-        that.broker.authorizeForward(that, _packet)
+      var toForward = dedupe(_packet)
       if (toForward) {
-        var packet = new QoSPacket(toForward, that)
-        packet.writeCallback = cb
-        if (that.clean) {
-          writeQoS(null, that, packet)
-        } else {
-          broker.persistence.outgoingUpdate(that, packet, writeQoS)
-        }
+        that.broker.authorizeForward(that, _packet, function (fwdPacket) {
+          if (fwdPacket) {
+            var packet = new QoSPacket(fwdPacket, that)
+            packet.writeCallback = cb
+            if (that.clean) {
+              writeQoS(null, that, packet)
+            } else {
+              broker.persistence.outgoingUpdate(that, packet, writeQoS)
+            }
+          } else if (that.clean === false) {
+            that.broker.persistence.outgoingClearMessageId(that, _packet, nop)
+            // we consider this to be an error, since the packet is undefined
+            // so there's nothing to send
+            cb()
+          } else {
+            cb()
+          }
+        })
       } else if (that.clean === false) {
         that.broker.persistence.outgoingClearMessageId(that, _packet, nop)
         // we consider this to be an error, since the packet is undefined
@@ -215,8 +230,7 @@ Client.prototype.close = function (done) {
 
   if (this.connected) {
     handleUnsubscribe(
-      this,
-      {
+      this, {
         close: true,
         unsubscriptions: Object.keys(this.subscriptions)
       },
@@ -277,7 +291,8 @@ Client.prototype.close = function (done) {
 
     if (conn.destroySoon) {
       conn.destroySoon()
-    } if (conn.destroy) {
+    }
+    if (conn.destroy) {
       conn.destroy()
     } else {
       conn.end()
@@ -303,4 +318,4 @@ function enqueue (packet) {
   handle(this.client, packet, this.client._nextBatch)
 }
 
-function nop () { }
+function nop () {}

--- a/lib/client.js
+++ b/lib/client.js
@@ -15,7 +15,7 @@ var handle = require('./handlers')
 
 module.exports = Client
 
-function Client(broker, conn) {
+function Client (broker, conn) {
   var that = this
 
   this.broker = broker
@@ -46,7 +46,7 @@ function Client(broker, conn) {
 
   this.parser.on('packet', enqueue)
 
-  function nextBatch(err) {
+  function nextBatch (err) {
     if (err) {
       return that.emit('error', err)
     }
@@ -80,7 +80,7 @@ function Client(broker, conn) {
 
   this._eos = eos(this.conn, this.close.bind(this))
 
-  function dedupe(packet) {
+  function dedupe (packet) {
     var duplicates = that.duplicates
     var id = packet.brokerId
     if (!id) {
@@ -94,10 +94,10 @@ function Client(broker, conn) {
     return result
   }
 
-  this.deliver0 = function deliverQoS0(_packet, cb) {
+  this.deliver0 = function deliverQoS0 (_packet, cb) {
     var toForward = dedupe(_packet)
     if (toForward) {
-      that.broker.authorizeForward(that, _packet, function(fwdPacket) {
+      that.broker.authorizeForward(that, _packet, function (fwdPacket) {
         if (fwdPacket) {
           var packet = new Packet(fwdPacket, broker)
           packet.qos = 0
@@ -111,14 +111,14 @@ function Client(broker, conn) {
     }
   }
 
-  this.deliverQoS = function deliverQoS(_packet, cb) {
+  this.deliverQoS = function deliverQoS (_packet, cb) {
     // downgrade to qos0 if requested by publish
     if (_packet.qos === 0) {
       that.deliver0(_packet, cb)
     } else {
       var toForward = dedupe(_packet)
       if (toForward) {
-        that.broker.authorizeForward(that, _packet, function(fwdPacket) {
+        that.broker.authorizeForward(that, _packet, function (fwdPacket) {
           if (fwdPacket) {
             var packet = new QoSPacket(fwdPacket, that)
             // Downgrading to client subscription qos if needed
@@ -155,12 +155,12 @@ function Client(broker, conn) {
   this._keepaliveTimer = null
   this._keepaliveInterval = -1
 
-  this._connectTimer = setTimeout(function() {
+  this._connectTimer = setTimeout(function () {
     that.emit('error', new Error('connect did not arrive in time'))
   }, broker.connectTimeout)
 }
 
-function writeQoS(err, client, packet) {
+function writeQoS (err, client, packet) {
   if (err) {
     // is this right, or we should ignore thins?
     client.emit('error', err)
@@ -169,7 +169,7 @@ function writeQoS(err, client, packet) {
   }
 }
 
-function onError(err) {
+function onError (err) {
   this.errored = true
   this.conn.removeAllListeners('error')
   this.conn.on('error', nop)
@@ -185,7 +185,7 @@ util.inherits(Client, EE)
 
 Client.prototype._onError = onError
 
-Client.prototype.publish = function(message, done) {
+Client.prototype.publish = function (message, done) {
   var packet = new Packet(message, this.broker)
   var that = this
   if (packet.qos === 0) {
@@ -194,7 +194,7 @@ Client.prototype.publish = function(message, done) {
   } else if (!this.clean && this.id) {
     this.broker.persistence.outgoingEnqueue({
       clientId: this.id
-    }, packet, function deliver(err) {
+    }, packet, function deliver (err) {
       if (err) {
         return done(err)
       }
@@ -205,7 +205,7 @@ Client.prototype.publish = function(message, done) {
   }
 }
 
-Client.prototype.subscribe = function(packet, done) {
+Client.prototype.subscribe = function (packet, done) {
   if (!packet.subscriptions) {
     if (!Array.isArray(packet)) {
       packet = [packet]
@@ -217,7 +217,7 @@ Client.prototype.subscribe = function(packet, done) {
   handleSubscribe(this, packet, done)
 }
 
-Client.prototype.unsubscribe = function(packet, done) {
+Client.prototype.unsubscribe = function (packet, done) {
   if (!packet.unsubscriptions) {
     if (!Array.isArray(packet)) {
       packet = [packet]
@@ -229,7 +229,7 @@ Client.prototype.unsubscribe = function(packet, done) {
   handleUnsubscribe(this, packet, done)
 }
 
-Client.prototype.close = function(done) {
+Client.prototype.close = function (done) {
   var that = this
   var conn = this.conn
 
@@ -261,17 +261,17 @@ Client.prototype.close = function(done) {
   this._eos()
   this._eos = nop
 
-  function finish() {
+  function finish () {
     if (!that.disconnected && that.will) {
       var will = Object.assign({}, that.will)
-      that.broker.authorizePublish(that, will, function(err) {
+      that.broker.authorizePublish(that, will, function (err) {
         if (!err) {
           that.broker.publish(will, that, done)
         } else {
           done()
         }
 
-        function done(err) {
+        function done (err) {
           if (!err) {
             that.broker.persistence.delWill({
               id: that.id,
@@ -308,18 +308,18 @@ Client.prototype.close = function(done) {
   }
 }
 
-Client.prototype.pause = function() {
+Client.prototype.pause = function () {
   this._paused = true
 }
 
-Client.prototype.resume = function() {
+Client.prototype.resume = function () {
   this._paused = false
   this._nextBatch()
 }
 
-function enqueue(packet) {
+function enqueue (packet) {
   this.client._parsingBatch++
   handle(this.client, packet, this.client._nextBatch)
 }
 
-function nop() {}
+function nop () {}

--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -186,13 +186,19 @@ function emptyQueueFilter (err, client, packet) {
   var authorized = true
 
   if (packet.cmd === 'publish') {
-    authorized = client.broker.authorizeForward(client, packet)
-  }
-
-  if (client.clean || !authorized) {
-    persistence.outgoingClearMessageId(client, packet, next)
+    client.broker.authorizeForward(client, packet, function (authorized) {
+      if (client.clean || !authorized) {
+        persistence.outgoingClearMessageId(client, packet, next)
+      } else {
+        write(client, packet, next)
+      }
+    })
   } else {
-    write(client, packet, next)
+    if (client.clean || !authorized) {
+      persistence.outgoingClearMessageId(client, packet, next)
+    } else {
+      write(client, packet, next)
+    }
   }
 }
 

--- a/test/auth.js
+++ b/test/auth.js
@@ -722,7 +722,7 @@ test('change a topic name inside authorizeForward method in QoS 1 mode', functio
     authorizeForward: function (client, packet, cb) {
       packet.payload = Buffer.from('another-world')
       packet.messageId = 2
-      return packet
+      cb(packet)
     }
   })
   var expected = {
@@ -765,7 +765,7 @@ test('prevent publish in QoS1 mode', function (t) {
 
   var broker = aedes({
     authorizeForward: function (client, packet, cb) {
-      return null
+      cb(null)
     }
   })
 
@@ -798,7 +798,7 @@ test('prevent publish in QoS0 mode', function (t) {
 
   var broker = aedes({
     authorizeForward: function (client, packet, cb) {
-      return null
+      cb(null)
     }
   })
 

--- a/test/typescript/typings.ts
+++ b/test/typescript/typings.ts
@@ -41,19 +41,19 @@ const aedes = Aedes({
 
     callback(null, sub)
   },
-  authorizeForward: (client, packet: IPublishPacket) => {
+  authorizeForward: (client, packet: IPublishPacket, callback) => {
     if (packet.topic === 'aaaa' && client.id === 'I should not see this') {
-      return null
+      callback(null)
       // also works with return undefined
     } else if (packet.topic === 'aaaa' && client.id === 'I should not see this either') {
-      return
+      callback()
     }
 
     if (packet.topic === 'bbb') {
       packet.payload = new Buffer('overwrite packet payload')
     }
 
-    return packet
+    callback(packet)
   }
 })
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -37,7 +37,7 @@ type AuthorizePublishCallback = (client: Client, packet: IPublishPacket, done: (
 
 type AuthorizeSubscribeCallback = (client: Client, subscription: ISubscription, done: (err: Error | null, subscription?: ISubscription | null) => void) => void
 
-type AuthorizeForwardCallback = (client: Client, packet: IPublishPacket) => IPublishPacket | null | void
+type AuthorizeForwardCallback = (client: Client, packet: IPublishPacket,done: (packet:IPublishPacket | null | void) => void) => void
 
 type PublishedCallback = (packet: IPublishPacket, client: Client, done: () => void) => void
 


### PR DESCRIPTION
Some async task can be performed now in authorizeForward before broker forwards this packet to consumer.
Let me know what you think and anything else needs to be changed. Thank you.
Note : This might be the breaking changes for the people who are already using this method by passing in options.