### PR TITLE
Fix bug while client subscribing to an Array of topics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,12 +275,12 @@ instance.authorizeSubscribe = function (client, sub, callback) {
 }
 ```
 
-To negate a subscription, set the subscription to `null`:
+To negate a subscription, set the subscription's QoS to `128`:
 
 ```js
 instance.authorizeSubscribe = function (client, sub, callback) {
   if (sub.topic === 'aaaa') {
-    sub = null
+    sub.qos = 128
   }
 
   callback(null, sub)

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -16,6 +16,7 @@ function SubscribeState (client, packet, finish, granted) {
   this.packet = packet
   this.finish = finish
   this.granted = granted
+  this.subsIndex = 0
 }
 
 function handleSubscribe (client, packet, done) {
@@ -65,15 +66,9 @@ function storeSubscriptions (sub, done) {
   var broker = client.broker
   var perst = broker.persistence
 
-  if (!sub) {
-    this.granted.push(128)
-    return done(null, sub)
-  }
-
-  if (sub && packet.subscriptions[0].topic !== sub.topic) {
-    // don't call addSubscriptions per topic,
-    // TODO change aedes subscribe handle, but this is a fast & dirty fix for now
-    return done(null, sub)
+  if(packet.subscriptions.length > 0 && ++this.subsIndex !== packet.subscriptions.length){
+      // TODO change aedes subscribe handle, but this fix bugs for now
+      return done(null, sub)
   }
 
   if (packet.restore) {


### PR DESCRIPTION
1.fix bug while client(MQTT.js) subscribing to an Array of topics. I am curious the original line use only subscriptions[0] in if condition that would ignore the rest topics in an Array.

2.fix bug while negating a subscription. The original logic is setting sub to null that will cause series problem. e.g: to negate multi topics and to persistent negated topics.

I am not sure whether this is a graceful solution but it can fix bugs of my project for now.