### PR TITLE
Fix bug while client subscribing to an Array of topics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,12 +275,12 @@ instance.authorizeSubscribe = function (client, sub, callback) {
 }
 ```
 
-To negate a subscription, set the subscription to `null`:
+To negate a subscription, set the subscription's QoS to `128`:
 
 ```js
 instance.authorizeSubscribe = function (client, sub, callback) {
   if (sub.topic === 'aaaa') {
-    sub = null
+    sub.qos = 128
   }
 
   callback(null, sub)

--- a/README.md
+++ b/README.md
@@ -275,12 +275,12 @@ instance.authorizeSubscribe = function (client, sub, callback) {
 }
 ```
 
-To negate a subscription, set the subscription's QoS to `128`:
+To negate a subscription, set the subscription to `null`:
 
 ```js
 instance.authorizeSubscribe = function (client, sub, callback) {
   if (sub.topic === 'aaaa') {
-    sub.qos = 128
+    sub = null
   }
 
   callback(null, sub)

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -68,7 +68,7 @@ function storeSubscriptions (sub, done) {
 
   if (!sub) {
     this.granted.push(128)
-    if (packet.subscriptions.length > 0) {
+    if (packet.subscriptions.length > 0 && packet.subscriptions[this.subsIndex]) {
       packet.subscriptions[this.subsIndex++]['qos'] = 128
     }
     return done(null, sub)

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -66,6 +66,11 @@ function storeSubscriptions (sub, done) {
   var broker = client.broker
   var perst = broker.persistence
 
+  if (!sub) {
+    this.granted.push(128)
+    return done(null, sub)
+  }
+
   if (packet.subscriptions.length > 0 && ++this.subsIndex !== packet.subscriptions.length) {
     // TODO change aedes subscribe handle, but this fix bugs for now.
     return done(null, sub)

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -68,10 +68,6 @@ function storeSubscriptions (sub, done) {
 
   if (!sub) {
     this.granted.push(128)
-    if (packet.subscriptions.length > 0 && packet.subscriptions[this.subsIndex]) {
-      packet.subscriptions[this.subsIndex++]['qos'] = 128
-    }
-    return done(null, sub)
   }
 
   if (packet.subscriptions.length > 0 && ++this.subsIndex < packet.subscriptions.length) {

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -74,7 +74,7 @@ function storeSubscriptions (sub, done) {
     return done(null, sub)
   }
 
-  if (packet.subscriptions.length > 0 && ++this.subsIndex !== packet.subscriptions.length) {
+  if (packet.subscriptions.length > 0 && ++this.subsIndex < packet.subscriptions.length) {
     // TODO change aedes subscribe handle, but this fix bugs for now.
     return done(null, sub)
   }

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -16,6 +16,7 @@ function SubscribeState (client, packet, finish, granted) {
   this.packet = packet
   this.finish = finish
   this.granted = granted
+  this.subsIndex = 0
 }
 
 function handleSubscribe (client, packet, done) {
@@ -65,14 +66,8 @@ function storeSubscriptions (sub, done) {
   var broker = client.broker
   var perst = broker.persistence
 
-  if (!sub) {
-    this.granted.push(128)
-    return done(null, sub)
-  }
-
-  if (sub && packet.subscriptions[0].topic !== sub.topic) {
-    // don't call addSubscriptions per topic,
-    // TODO change aedes subscribe handle, but this is a fast & dirty fix for now
+  if (packet.subscriptions.length > 0 && ++this.subsIndex !== packet.subscriptions.length) {
+    // TODO change aedes subscribe handle, but this fix bugs for now.
     return done(null, sub)
   }
 

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -68,6 +68,9 @@ function storeSubscriptions (sub, done) {
 
   if (!sub) {
     this.granted.push(128)
+    if (packet.subscriptions.length > 0) {
+      packet.subscriptions[this.subsIndex++]['qos'] = 128
+    }
     return done(null, sub)
   }
 


### PR DESCRIPTION
1.fix bug while client(MQTT.js) subscribing to an Array of topics. I am curious the original line use only subscriptions[0] in if condition that would ignore the rest topics in an Array.

-2.fix bug while negating a subscription. The original logic is setting sub to null that will cause series problem. e.g: to negate multi topics and to persistent negated topics (which QoS is still 0 in storage).

-----------------

I retract #2 to pass test case with bugs I mentioned. Maybe you can change this part while you have time :)

--------------------------

I fixed negated topics persistence bug in the third commit.

Multi topics negating bug is still there.
```
instance.authorizeSubscribe = function (client, sub, callback) {
  if (sub.topic === 'aaaa') {
    sub = null
  }
  if (sub.topic === 'bbbb') { //bug here
    sub = null
  }
  callback(null, sub)
}
```
 I have tried to fix it but it seems to be related several parts and cannot pass test case.

I am not sure whether this is a graceful solution but it can fix bugs of my project for now.