### PR TITLE
Prolong waiting time

### DIFF
--- a/test/keep-alive.js
+++ b/test/keep-alive.js
@@ -60,12 +60,12 @@ test('disconnect if a connect does not arrive in time', function (t) {
   t.timeoutAfter(200)
 
   var s = setup(aedes({
-    connectTimeout: 50
+    connectTimeout: 100
   }))
   var start = Date.now()
 
   eos(s.conn, function () {
-    t.ok(Date.now() >= start + 50, 'waits waitConnectTimeout before ending')
+    t.ok(Date.now() >= start + 100, 'waits waitConnectTimeout before ending')
     t.pass('ended')
   })
 })


### PR DESCRIPTION
Travis CI sometimes is too slow, and is causing aedes broker not respond and fails the 'disconnect if a connect does not arrive in time' test