### PR TITLE
same messageId in qos 1 & 2

### DIFF
--- a/aedes.js
+++ b/aedes.js
@@ -230,6 +230,7 @@ Aedes.prototype.publish = function (packet, client, done) {
   var p = new Packet(packet, this)
   var publishFuncs = publishFuncsSimple
   if (p.qos > 0) {
+    p.messageId = packet.messageId
     publishFuncs = publishFuncsQoS
   }
   this._series(new PublishState(this, client, p), publishFuncs, null, done)

--- a/lib/client.js
+++ b/lib/client.js
@@ -177,17 +177,20 @@ Client.prototype.publish = function (message, done) {
   if (packet.qos === 0) {
     // skip offline and send it as it is
     this.deliver0(packet, done || nop)
-  } else if (!this.clean && this.id) {
-    this.broker.persistence.outgoingEnqueue({
-      clientId: this.id
-    }, packet, function deliver (err) {
-      if (err) {
-        return done(err)
-      }
-      that.deliverQoS(packet, done)
-    })
   } else {
-    that.deliverQoS(packet, done)
+    packet.messageId = message.messageId
+    if (!this.clean && this.id) {
+      this.broker.persistence.outgoingEnqueue({
+        clientId: this.id
+      }, packet, function deliver (err) {
+        if (err) {
+          return done(err)
+        }
+        that.deliverQoS(packet, done)
+      })
+    } else {
+      that.deliverQoS(packet, done)
+    }
   }
 }
 

--- a/test/qos1.js
+++ b/test/qos1.js
@@ -338,7 +338,8 @@ test('do not resend QoS 1 packets at reconnect if puback was received', function
     qos: 1,
     dup: false,
     length: 14,
-    retain: false
+    retain: false,
+    messageId: 42
   }
 
   subscribe(t, subscriber, 'hello', 1, function () {
@@ -362,7 +363,6 @@ test('do not resend QoS 1 packets at reconnect if puback was received', function
         messageId: packet.messageId
       })
 
-      delete packet.messageId
       t.deepEqual(packet, expected, 'packet must match')
 
       subscriber = connect(setup(broker), { clean: false, clientId: 'abcde' })
@@ -423,12 +423,12 @@ test('deliver QoS 1 retained messages', function (t) {
     qos: 1,
     dup: false,
     length: 14,
-    retain: false
+    retain: false,
+    messageId: 42
   }
 
   subscribe(t, subscriber, 'hello', 1, function () {
     subscriber.outStream.once('data', function (packet) {
-      delete packet.messageId
       t.deepEqual(packet, expected, 'packet must match')
       t.end()
     })

--- a/test/qos1.js
+++ b/test/qos1.js
@@ -44,7 +44,8 @@ test('subscribe QoS 1', function (t) {
     qos: 1,
     dup: false,
     length: 14,
-    retain: false
+    retain: false,
+    messageId: 42
   }
 
   subscribe(t, subscriber, 'hello', 1, function () {
@@ -53,8 +54,6 @@ test('subscribe QoS 1', function (t) {
         cmd: 'puback',
         messageId: packet.messageId
       })
-      t.notEqual(packet.messageId, 42, 'messageId must differ')
-      delete packet.messageId
       t.deepEqual(packet, expected, 'packet must match')
       t.end()
     })
@@ -110,7 +109,8 @@ test('restore QoS 1 subscriptions not clean', function (t) {
     qos: 1,
     dup: false,
     length: 14,
-    retain: false
+    retain: false,
+    messageId: 42
   }
 
   subscribe(t, subscriber, 'hello', 1, function () {
@@ -138,8 +138,6 @@ test('restore QoS 1 subscriptions not clean', function (t) {
         cmd: 'puback',
         messageId: packet.messageId
       })
-      t.notEqual(packet.messageId, 42, 'messageId must differ')
-      delete packet.messageId
       t.deepEqual(packet, expected, 'packet must match')
       t.end()
     })
@@ -204,7 +202,8 @@ test('resend publish on non-clean reconnect QoS 1', function (t) {
     qos: 1,
     dup: false,
     length: 14,
-    retain: false
+    retain: false,
+    messageId: 42
   }
 
   subscribe(t, subscriber, 'hello', 1, function () {
@@ -230,8 +229,6 @@ test('resend publish on non-clean reconnect QoS 1', function (t) {
           cmd: 'puback',
           messageId: packet.messageId
         })
-        t.notEqual(packet.messageId, 42, 'messageId must differ')
-        delete packet.messageId
         t.deepEqual(packet, expected, 'packet must match')
         t.end()
       })
@@ -250,7 +247,8 @@ test('do not resend QoS 1 packets at each reconnect', function (t) {
     qos: 1,
     dup: false,
     length: 14,
-    retain: false
+    retain: false,
+    messageId: 42
   }
 
   subscribe(t, subscriber, 'hello', 1, function () {
@@ -277,8 +275,6 @@ test('do not resend QoS 1 packets at each reconnect', function (t) {
           messageId: packet.messageId
         })
 
-        t.notEqual(packet.messageId, 42, 'messageId must differ')
-        delete packet.messageId
         t.deepEqual(packet, expected, 'packet must match')
 
         var subscriber2 = connect(setup(broker), { clean: false, clientId: 'abcde' })
@@ -648,23 +644,17 @@ test('not clean and retain messages with QoS 1', function (t) {
       })
 
       subscriber.outStream.once('data', function (packet) {
-        t.notEqual(packet.messageId, 42, 'messageId must differ')
         t.equal(packet.qos, 0, 'qos degraded to 0 for retained')
-        var prevId = packet.messageId
-        delete packet.messageId
         packet.qos = 1
         packet.length = 14
         t.deepEqual(packet, expected, 'packet must match')
 
         // message is duplicated
         subscriber.outStream.once('data', function (packet2) {
-          var curId = packet2.messageId
-          t.notOk(curId === prevId, 'messageId must differ')
           subscriber.inStream.write({
             cmd: 'puback',
-            messageId: curId
+            messageId: packet2.messageId
           })
-          delete packet2.messageId
           t.deepEqual(packet, expected, 'packet must match')
 
           t.end()
@@ -684,7 +674,8 @@ test('subscribe and publish QoS 1 in parallel', function (t) {
     qos: 1,
     dup: false,
     length: 14,
-    retain: false
+    retain: false,
+    messageId: 42
   }
 
   broker.on('clientError', function (client, err) {
@@ -700,7 +691,6 @@ test('subscribe and publish QoS 1 in parallel', function (t) {
         cmd: 'puback',
         messageId: packet.messageId
       })
-      delete packet.messageId
       t.deepEqual(packet, expected, 'packet must match')
       s.outStream.once('data', function (packet) {
         t.equal(packet.cmd, 'suback')

--- a/test/qos2.js
+++ b/test/qos2.js
@@ -217,12 +217,12 @@ test('subscribe QoS 1, but publish QoS 2', function (t) {
     qos: 1,
     dup: false,
     length: 14,
-    retain: false
+    retain: false,
+    messageId: 42
   }
 
   subscribe(t, subscriber, 'hello', 1, function () {
     subscriber.outStream.once('data', function (packet) {
-      delete packet.messageId
       t.deepEqual(packet, expected, 'packet must match')
       t.end()
     })

--- a/test/qos2.js
+++ b/test/qos2.js
@@ -47,11 +47,8 @@ function publish (t, s, packet, done) {
 
 function receive (t, subscriber, expected, done) {
   subscriber.outStream.once('data', function (packet) {
-    t.notEqual(packet.messageId, expected.messageId, 'messageId must differ')
-
     var msgId = packet.messageId
-    delete packet.messageId
-    delete expected.messageId
+
     t.deepEqual(packet, expected, 'packet must match')
 
     subscriber.inStream.write({
@@ -146,7 +143,7 @@ test('client.publish with clean=true subscribption QoS 2', function (t) {
 })
 
 test('call published method with client with QoS 2', function (t) {
-  t.plan(10)
+  t.plan(9)
 
   var broker = aedes()
   var publisher = connect(setup(broker))
@@ -325,11 +322,8 @@ test('resend pubrel on non-clean reconnect QoS 2', function (t) {
       subscriber = connect(setup(broker), opts)
 
       subscriber.outStream.once('data', function (packet) {
-        t.notEqual(packet.messageId, expected.messageId, 'messageId must differ')
-
         var msgId = packet.messageId
-        delete packet.messageId
-        delete expected.messageId
+
         t.deepEqual(packet, expected, 'packet must match')
 
         subscriber.inStream.write({


### PR DESCRIPTION
in QoS 1 and 2, a PUBACK, PUBREC or PUBREL Packet MUST contain the same Packet Identifier as the PUBLISH Packet that was originally sent [MQTT-2.3.1-6]