### PR TITLE
Check CONNECT and add tests

### DIFF
--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -10,7 +10,12 @@ var handlePubrec = require('./pubrec')
 var handlePing = require('./ping')
 
 function handle (client, packet, done) {
-  if (packet.cmd !== 'connect' && !client.connected) {
+  if (
+    // [MQTT-3.1.0-1]
+    (packet.cmd !== 'connect' && !client.connected) ||
+    // [MQTT-3.1.0-2]
+    (packet.cmd === 'connect' && client.connected)
+  ) {
     client.conn.destroy()
     return
   }

--- a/test/basic.js
+++ b/test/basic.js
@@ -52,12 +52,12 @@ test('the first Packet sent from the Client to the Server MUST be a CONNECT Pack
     retain: false
   }
   s.inStream.write(packet)
-  setTimeout(() => {
+  setImmediate(() => {
     t.ok(s.conn.destroyed, 'close connection if first packet is not a CONNECT')
     s.conn.destroy()
     broker.close()
     t.end()
-  }, 100)
+  })
 })
 
 test('second CONNECT Packet sent from a Client as a protocol violation and disconnect the Client [MQTT-3.1.0-2]', function (t) {
@@ -75,15 +75,14 @@ test('second CONNECT Packet sent from a Client as a protocol violation and disco
   var s = connect(setup(broker, false), { clientId: 'abcde' }, function () {
     t.ok(broker.clients['abcde'].connected)
     s.inStream.write(packet)
+    setImmediate(() => {
+      t.equal(broker.clients['abcde'], undefined, 'client instance is removed')
+      t.ok(s.conn.destroyed, 'close connection if packet is a CONNECT after network is established')
+      s.conn.destroy()
+      broker.close()
+      t.end()
+    })
   })
-
-  setTimeout(() => {
-    t.equal(broker.clients['abcde'], undefined, 'client instance is removed')
-    t.ok(s.conn.destroyed, 'close connection if packet is a CONNECT after network is established')
-    s.conn.destroy()
-    broker.close()
-    t.end()
-  }, 100)
 })
 
 test('publish QoS 0', function (t) {
@@ -364,14 +363,14 @@ test('client closes', function (t) {
   var client = noError(connect(setup(broker, false), { clientId: 'abcde' }))
   eos(client.conn, t.pass.bind('client closes'))
 
-  setTimeout(() => {
+  setImmediate(() => {
     broker.clients['abcde'].close(function () {
       t.equal(broker.clients['abcde'], undefined, 'client instance is removed')
       broker.close(function (err) {
         t.error(err, 'no error')
       })
     })
-  }, 200)
+  })
 })
 
 test('broker closes', function (t) {
@@ -381,12 +380,12 @@ test('broker closes', function (t) {
   var client = noError(connect(setup(broker, false), { clientId: 'abcde' }))
   eos(client.conn, t.pass.bind('client closes'))
 
-  setTimeout(() => {
+  setImmediate(() => {
     broker.close(function (err) {
       t.error(err, 'no error')
       t.equal(broker.clients['abcde'], undefined, 'client instance is removed')
     })
-  }, 200)
+  })
 })
 
 test('broker closes gracefully', function (t) {
@@ -398,12 +397,12 @@ test('broker closes gracefully', function (t) {
   eos(client1.conn, t.pass.bind('client1 closes'))
   eos(client2.conn, t.pass.bind('client2 closes'))
 
-  setTimeout(() => {
+  setImmediate(() => {
     broker.close(function (err) {
       t.error(err, 'no error')
       t.ok(broker.mq.closed, 'broker mq closes')
     })
-  }, 200)
+  })
 })
 
 test('testing other event', function (t) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -38,6 +38,44 @@ test('connect and connack (minimal)', function (t) {
   })
 })
 
+test('the first Packet sent from the Client to the Server MUST be a CONNECT Packet [MQTT-3.1.0-1]', function (t) {
+  var s = setup()
+
+  var packet = {
+    cmd: 'publish',
+    topic: 'hello',
+    payload: Buffer.from('world'),
+    qos: 0,
+    retain: false
+  }
+  s.inStream.write(packet)
+  setTimeout(() => {
+    t.ok(s.conn.destroyed, 'close connection if first packet is not a CONNECT')
+    s.conn.destroy()
+    t.end()
+  }, 100)
+})
+
+test('second CONNECT Packet sent from a Client as a protocol violation and disconnect the Client [MQTT-3.1.0-2]', function (t) {
+  var s = connect(setup())
+
+  var packet = {
+    cmd: 'connect',
+    protocolId: 'MQTT',
+    protocolVersion: 4,
+    clean: true,
+    clientId: 'my-client',
+    keepalive: 0
+  }
+
+  s.inStream.write(packet)
+  setTimeout(() => {
+    t.ok(s.conn.destroyed, 'close connection if packet is a CONNECT after network is established')
+    s.conn.destroy()
+    t.end()
+  }, 100)
+})
+
 test('publish QoS 0', function (t) {
   var s = connect(setup())
   var expected = {


### PR DESCRIPTION
> After a Network Connection is established by a Client to a Server, the first Packet sent from the Client to the Server MUST be a CONNECT Packet [MQTT-3.1.0-1].

> A Client can only send the CONNECT Packet once over a Network Connection. The Server MUST process a second CONNECT Packet sent from a Client as a protocol violation and disconnect the Client [MQTT-3.1.0-2]