### PR TITLE
Packet in ack event is PUBREL in QoS 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Events:
   2. `client`, it will be null if the message is published using
      [`publish`](#publish). It is by design that the broker heartbeat will be on publish event, in this case `client` is null
 * `ack`: when a packet published to a client is delivered successfully with QoS 1 or QoS 2, arguments:
-  1. `packet`
+  1. `packet`, this will be the original PUBLISH packet in QoS 1, and PUBREL in QoS 2
   2. `client`
 * `ping`: when a [Client](#client) sends a ping, arguments:
   1. `packet`

--- a/test/client-pub-sub.js
+++ b/test/client-pub-sub.js
@@ -112,7 +112,7 @@ test('emit a `ack` event on PUBACK for QoS 1', function (t) {
 })
 
 test('emit a `ack` event on PUBCOMP for QoS 2', function (t) {
-  t.plan(6)
+  t.plan(5)
 
   var broker = aedes()
   var messageId
@@ -132,8 +132,7 @@ test('emit a `ack` event on PUBCOMP for QoS 2', function (t) {
   broker.once('ack', function (packet, client) {
     t.equal(client.id, clientId)
     t.equal(packet.messageId, messageId)
-    t.equal(packet.topic, 'hello')
-    t.equal(packet.payload.toString(), 'world')
+    t.equal(packet.cmd, 'pubrel')
     t.pass('got the ack event')
   })
 


### PR DESCRIPTION
Relates to https://github.com/mcollina/aedes/issues/257

Passing CI test requires mcollina/aedes-persistence#33