### PR TITLE
Forcibly close a subscriber socket should not affect others

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -289,6 +289,9 @@ Client.prototype.close = function (done) {
       conn.end()
     }
 
+    that.connected = false
+    that.disconnected = true
+
     if (typeof done === 'function') {
       done()
     }

--- a/lib/write.js
+++ b/lib/write.js
@@ -3,11 +3,15 @@
 var mqtt = require('mqtt-packet')
 
 function write (client, packet, done) {
-  var result = mqtt.writeToStream(packet, client.conn)
-
-  if (!result && !client.errored && done) {
-    client.conn.once('drain', done)
-  } else if (done) {
+  if (client.conn.writable) {
+    var result = mqtt.writeToStream(packet, client.conn)
+    if (!result && !client.errored && done) {
+      console.log('drain')
+      client.conn.once('drain', done)
+      return
+    }
+  }
+  if (done) {
     setImmediate(done)
   }
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -292,20 +292,27 @@ test('disconnect', function (t) {
 })
 
 test('client closes', function (t) {
-  t.plan(3)
+  t.plan(7)
 
   var broker = aedes()
-  var client = noError(connect(setup(broker, false), { clientId: 'abcde' }))
+  var brokerClient
+  var client = noError(connect(setup(broker, false), { clientId: 'abcde' }, function () {
+    brokerClient = broker.clients['abcde']
+    t.equal(brokerClient.connected, true, 'client connected')
+    t.equal(brokerClient.disconnected, false)
   eos(client.conn, t.pass.bind('client closes'))
-
   setImmediate(() => {
-    broker.clients['abcde'].close(function () {
+      brokerClient.close(function () {
       t.equal(broker.clients['abcde'], undefined, 'client instance is removed')
+      })
+      t.equal(brokerClient.connected, false, 'client disconnected')
+      t.equal(brokerClient.disconnected, true)
       broker.close(function (err) {
         t.error(err, 'no error')
-      })
+        t.end()
     })
   })
+  }))
 })
 
 test('broker closes', function (t) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -300,18 +300,18 @@ test('client closes', function (t) {
     brokerClient = broker.clients['abcde']
     t.equal(brokerClient.connected, true, 'client connected')
     t.equal(brokerClient.disconnected, false)
-  eos(client.conn, t.pass.bind('client closes'))
-  setImmediate(() => {
+    eos(client.conn, t.pass.bind('client closes'))
+    setImmediate(() => {
       brokerClient.close(function () {
-      t.equal(broker.clients['abcde'], undefined, 'client instance is removed')
+        t.equal(broker.clients['abcde'], undefined, 'client instance is removed')
       })
       t.equal(brokerClient.connected, false, 'client disconnected')
       t.equal(brokerClient.disconnected, true)
       broker.close(function (err) {
         t.error(err, 'no error')
         t.end()
+      })
     })
-  })
   }))
 })
 

--- a/test/close_socket_by_other_party.js
+++ b/test/close_socket_by_other_party.js
@@ -1,0 +1,53 @@
+'use strict'
+
+var test = require('tape').test
+
+test('multiple clients subscribe same topic, and all clients still receive message except the closed one', function (t) {
+  t.plan(4)
+
+  var mqtt = require('mqtt')
+  var aedes = require('../')()
+  var server = require('net').createServer(aedes.handle)
+  var port = 1883
+  server.listen(port)
+  aedes.on('clientError', function (client, err) {
+    t.error(err)
+  })
+
+  var client1, client2
+  var _sameTopic = 'hello'
+
+  // client 1
+  client1 = mqtt.connect('mqtt://localhost', { clientId: 'client1', resubscribe: false })
+  client1.on('message', () => {
+    t.fail('client1 receives message')
+  })
+
+  client1.subscribe(_sameTopic, { qos: 0, retain: false }, () => {
+    t.pass('client1 sub callback')
+    // stimulate closed socket by users
+    client1.stream.destroy()
+
+    // client 2
+    client2 = mqtt.connect('mqtt://localhost', { clientId: 'client2', resubscribe: false })
+    client2.on('message', () => {
+      t.pass('client2 receives message')
+    })
+    client2.subscribe(_sameTopic, { qos: 0, retain: false }, () => {
+      t.pass('client2 sub callback')
+
+      // pubClient
+      var pubClient = mqtt.connect('mqtt://localhost', { clientId: 'pubClient' })
+      pubClient.publish(_sameTopic, 'world', { qos: 0, retain: false }, () => {
+        t.pass('pubClient publish event')
+        pubClient.end()
+      })
+    })
+  })
+  setTimeout(() => {
+    client1.end()
+    client2.end()
+    aedes.close()
+    server.close()
+  }, 2000)
+})


### PR DESCRIPTION
When multiple subscribers listen a same topic, the other subscribers should still receive messages even one of them is destroyed. Refer to issue https://github.com/mcollina/aedes/issues/246