### PR TITLE
The QoS of retained messages should depend on subscribers

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -122,7 +122,7 @@ function Client (broker, conn) {
           packet.qos = clientSub.qos
         }
         packet.writeCallback = cb
-        if (that.clean) {
+        if (that.clean || packet.retain) {
           writeQoS(null, that, packet)
         } else {
           broker.persistence.outgoingUpdate(that, packet, writeQoS)

--- a/lib/client.js
+++ b/lib/client.js
@@ -118,7 +118,7 @@ function Client (broker, conn) {
         var packet = new QoSPacket(toForward, that)
         // Downgrading to client subscription qos if needed
         var clientSub = that.subscriptions[packet.topic]
-        if (clientSub && clientSub.qos && clientSub.qos < packet.qos) {
+        if (clientSub && (clientSub.qos || 0) < packet.qos) {
           packet.qos = clientSub.qos
         }
         packet.writeCallback = cb

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -174,7 +174,7 @@ function completeSubscribe (err) {
     }, broker)
     // this should not be deduped
     packet.brokerId = null
-    client.deliver0(packet, cb)
+    client.deliverQoS(packet, cb)
   }))
 }
 

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -165,7 +165,13 @@ function completeSubscribe (err) {
   }
   var stream = persistence.createRetainedStreamCombi(topics)
   stream.pipe(through.obj(function sendRetained (packet, enc, cb) {
-    packet = new Packet(packet)
+    packet = new Packet({
+      cmd: packet.cmd,
+      qos: packet.qos,
+      topic: packet.topic,
+      payload: packet.payload,
+      retain: true
+    }, broker)
     // this should not be deduped
     packet.brokerId = null
     client.deliver0(packet, cb)

--- a/test/retain.js
+++ b/test/retain.js
@@ -161,8 +161,8 @@ test('reconnected subscriber will not receive retained messages when QoS 0 and c
 })
 
 // [MQTT-3.3.1-6]
-test('new subscribers receive retained messages when QoS 0 and clean', function (t) {
-  t.plan(8)
+test('new QoS 0 subscribers receive QoS 0 retained messages when clean', function (t) {
+  t.plan(9)
 
   var broker = aedes()
   var publisher = connect(setup(broker), { clean: true })
@@ -194,7 +194,11 @@ test('new subscribers receive retained messages when QoS 0 and clean', function 
       t.deepEqual(packet, expected, 'packet must match')
     })
   })
-  broker.on('closed', t.end.bind(t))
+  broker.on('closed', function () {
+    t.equal(broker.counter, 9)
+    t.end()
+  })
+})
 })
 
 // [MQTT-3.3.1-10]

--- a/test/retain.js
+++ b/test/retain.js
@@ -224,15 +224,19 @@ test('new QoS 0 subscribers receive downgraded QoS 1 retained messages when clea
     retain: true,
     messageId: 42
   })
-  var subscriber = connect(setup(broker, false), { clean: true })
-  subscribe(t, subscriber, 'hello', 0, function () {
-    subscriber.outStream.on('data', function (packet) {
-      t.notEqual(packet.messageId, 42, 'messageId should not be the same')
-      delete packet.messageId
-      t.deepEqual(packet, expected, 'packet must match')
-      t.equal(broker.counter, 4)
-      t.end()
+  publisher.outStream.on('data', function (packet) {
+    var subscriber = connect(setup(broker, false), { clean: true })
+    subscribe(t, subscriber, 'hello', 0, function () {
+      subscriber.outStream.on('data', function (packet) {
+        t.notEqual(packet.messageId, 42, 'messageId should not be the same')
+        delete packet.messageId
+        t.deepEqual(packet, expected, 'packet must match')
+      })
     })
+  })
+  broker.on('closed', function () {
+    t.equal(broker.counter, 6)
+    t.end()
   })
 })
 

--- a/test/retain.js
+++ b/test/retain.js
@@ -223,7 +223,7 @@ test('new QoS 0 subscribers receive downgraded QoS 1 retained messages when clea
     qos: 1,
     retain: true,
     messageId: 42
-})
+  })
   var subscriber = connect(setup(broker, false), { clean: true })
   subscribe(t, subscriber, 'hello', 0, function () {
     subscriber.outStream.on('data', function (packet) {

--- a/test/retain.js
+++ b/test/retain.js
@@ -10,6 +10,7 @@ var connect = helper.connect
 var noError = helper.noError
 var subscribe = helper.subscribe
 
+// [MQTT-3.3.1-9]
 test('live retain packets', function (t) {
   t.plan(5)
   var expected = {

--- a/test/retain.js
+++ b/test/retain.js
@@ -273,7 +273,7 @@ test('broker not store zero-byte retained messages', function (t) {
     payload: '',
     retain: true
   })
-  s.broker.on('publish', function (packet, client){
+  s.broker.on('publish', function (packet, client) {
     if (packet.topic.startsWith('$SYS/')) {
       return
     }
@@ -313,9 +313,9 @@ test('fail to clean retained messages without retain flag', function (t) {
     qos: 0,
     retain: false
   })
-  var subscriber1 = connect(setup(broker, false), { clean: true })
-  subscribe(t, subscriber1, 'hello', 0, function () {
-    subscriber1.outStream.on('data', function (packet) {
+  var subscriber = connect(setup(broker, false), { clean: true })
+  subscribe(t, subscriber, 'hello', 0, function () {
+    subscriber.outStream.on('data', function (packet) {
       t.deepEqual(packet, expected, 'packet must match')
     })
   })
@@ -350,9 +350,9 @@ test('only get the last retained messages in same topic', function (t) {
     qos: 0,
     retain: true
   })
-  var subscriber1 = connect(setup(broker, false), { clean: true })
-  subscribe(t, subscriber1, 'hello', 0, function () {
-    subscriber1.outStream.on('data', function (packet) {
+  var subscriber = connect(setup(broker, false), { clean: true })
+  subscribe(t, subscriber, 'hello', 0, function () {
+    subscriber.outStream.on('data', function (packet) {
       t.deepEqual(packet, expected, 'packet must match')
     })
   })


### PR DESCRIPTION
From MQTT 3.1.1 spec
> If the RETAIN flag is set to 1, in a PUBLISH Packet sent by a Client to a Server, the Server MUST store the Application Message and its QoS, so that it can be delivered to future subscribers whose subscriptions match its topic name [MQTT-3.3.1-5]

We store the retained message QoS in a persistence store. If the retain message is QoS 1
Subscriber (QoS 2) will get the retained msg in QoS 1
Subscriber (QoS 1) will get the retained msg in QoS 1
Subscriber (QoS 0) will get the retained msg in QoS 0 (downgraded)