### PR TITLE
Fixed "Maximum call stack size exceeded"

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -94,7 +94,7 @@ function Client (broker, conn) {
         write(that, packet, cb)
       })
     } else {
-      cb()
+      setImmediate(cb)
     }
   }
 
@@ -125,9 +125,9 @@ function Client (broker, conn) {
       that.broker.persistence.outgoingClearMessageId(that, _packet, nop)
       // we consider this to be an error, since the packet is undefined
       // so there's nothing to send
-      cb()
+      setImmediate(cb)
     } else {
-      cb()
+      setImmediate(cb)
     }
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -86,9 +86,13 @@ function Client (broker, conn) {
     var toForward = dedupe(that, _packet) &&
       that.broker.authorizeForward(that, _packet)
     if (toForward) {
-      var packet = new Packet(toForward, broker)
-      packet.qos = 0
-      write(that, packet, cb)
+      // Give nodejs some time to clear stacks, or we will see
+      // "Maximum call stack size exceeded" in a very high load
+      setImmediate(() => {
+        var packet = new Packet(toForward, broker)
+        packet.qos = 0
+        write(that, packet, cb)
+      })
     } else {
       cb()
     }
@@ -103,18 +107,20 @@ function Client (broker, conn) {
     var toForward = dedupe(that, _packet) &&
       that.broker.authorizeForward(that, _packet)
     if (toForward) {
-      var packet = new QoSPacket(toForward, that)
-      // Downgrading to client subscription qos if needed
-      var clientSub = that.subscriptions[packet.topic]
-      if (clientSub && (clientSub.qos || 0) < packet.qos) {
-        packet.qos = clientSub.qos
-      }
-      packet.writeCallback = cb
-      if (that.clean || packet.retain) {
-        writeQoS(null, that, packet)
-      } else {
-        broker.persistence.outgoingUpdate(that, packet, writeQoS)
-      }
+      setImmediate(() => {
+        var packet = new QoSPacket(toForward, that)
+        // Downgrading to client subscription qos if needed
+        var clientSub = that.subscriptions[packet.topic]
+        if (clientSub && (clientSub.qos || 0) < packet.qos) {
+          packet.qos = clientSub.qos
+        }
+        packet.writeCallback = cb
+        if (that.clean || packet.retain) {
+          writeQoS(null, that, packet)
+        } else {
+          broker.persistence.outgoingUpdate(that, packet, writeQoS)
+        }
+      })
     } else if (that.clean === false) {
       that.broker.persistence.outgoingClearMessageId(that, _packet, nop)
       // we consider this to be an error, since the packet is undefined


### PR DESCRIPTION
Attempt to fix "Maximum call stack size exceeded"  …
Reported in #193
This could be reproduced using benchmark/server.js, benchmark/throughputCounter.js and benchmark/bombing.js
Once all three processes are up, stay a while and SIGINT the throughtputCounter.js