### PR TITLE
Dedupe subscriptions

### DIFF
--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -40,7 +40,7 @@ function handleSubscribe (client, packet, done) {
   broker._series(
     new SubscribeState(client, packet, done, granted),
     doSubscribe,
-    subs.length === 0 ? subs : _dedupe(subs),
+    subs.length === 1 ? subs : _dedupe(subs),
     completeSubscribe)
 }
 

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -22,9 +22,10 @@ function SubscribeState (client, packet, finish, granted) {
 // if same subscribed topic in subs array, we pick up the last one
 function _dedupe (subs) {
   var dedupeSubs = {}
-  subs.forEach(function (el) {
-    dedupeSubs[el.topic] = el
-  })
+  for (var i = 0; i < subs.length; i++) {
+    var sub = subs[i]
+    dedupeSubs[sub.topic] = sub
+  }
   var ret = []
   for (var key in dedupeSubs) {
     ret.push(dedupeSubs[key])

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -19,6 +19,19 @@ function SubscribeState (client, packet, finish, granted) {
   this.subsIndex = 0
 }
 
+// if same subscribed topic in subs array, we pick up the last one
+function _dedupe (subs) {
+  var dedupeSubs = {}
+  subs.forEach(function (el) {
+    dedupeSubs[el.topic] = el
+  })
+  var ret = []
+  for (var key in dedupeSubs) {
+    ret.push(dedupeSubs[key])
+  }
+  return ret
+}
+
 function handleSubscribe (client, packet, done) {
   var broker = client.broker
   var subs = packet.subscriptions
@@ -27,7 +40,7 @@ function handleSubscribe (client, packet, done) {
   broker._series(
     new SubscribeState(client, packet, done, granted),
     doSubscribe,
-    subs,
+    subs.length === 0 ? subs : _dedupe(subs),
     completeSubscribe)
 }
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -95,9 +95,29 @@ function subscribe (t, subscriber, topic, qos, done) {
   })
 }
 
+// subs: [{topic:, qos:}]
+function subscribeMultiple (t, subscriber, subs, expectedGranted, done) {
+  subscriber.inStream.write({
+    cmd: 'subscribe',
+    messageId: 24,
+    subscriptions: subs
+  })
+
+  subscriber.outStream.once('data', function (packet) {
+    t.equal(packet.cmd, 'suback')
+    t.deepEqual(packet.granted, expectedGranted)
+    t.equal(packet.messageId, 24)
+
+    if (done) {
+      done(null, packet)
+    }
+  })
+}
+
 module.exports = {
   setup: setup,
   connect: connect,
   noError: noError,
-  subscribe: subscribe
+  subscribe: subscribe,
+  subscribeMultiple: subscribeMultiple
 }


### PR DESCRIPTION
If there are duplicated topics in subscriptions, no matter what QoS is, we pick the last one.
say the subscriptions in SUBSCRIBE are
```
[{ topic: 'hello', qos: 1 }, { topic: 'hello', qos: 0 }]
```
the actual subscription is only `{ topic: 'hello', qos: 0 }`

Vernemq and mosquitto are in same behaviour.