### PR TITLE
Not send retained messages when restoring subscriptions for clean=false clients

### DIFF
--- a/lib/handlers/connect.js
+++ b/lib/handlers/connect.js
@@ -211,6 +211,8 @@ function doConnack (arg, done) {
   })
 }
 
+// push any queued messages (included retained messages) at the disconnected time
+// when QoS > 0 and session is true
 function emptyQueue (arg, done) {
   var client = this.client
   var persistence = client.broker.persistence

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -172,24 +172,29 @@ function completeSubscribe (err) {
     done()
   }
 
-  var persistence = broker.persistence
-  var topics = []
-  for (var i = 0; i < subs.length; i++) {
-    topics.push(subs[i].topic)
+  // Conform to MQTT 3.1.1 section 3.1.2.4
+  // Restored sessions should not contain any retained message.
+  // Retained message should be only fetched from SUBSCRIBE.
+  if (!packet.restore) {
+    var persistence = broker.persistence
+    var topics = []
+    for (var i = 0; i < subs.length; i++) {
+      topics.push(subs[i].topic)
+    }
+    var stream = persistence.createRetainedStreamCombi(topics)
+    stream.pipe(through.obj(function sendRetained (packet, enc, cb) {
+      packet = new Packet({
+        cmd: packet.cmd,
+        qos: packet.qos,
+        topic: packet.topic,
+        payload: packet.payload,
+        retain: true
+      }, broker)
+      // this should not be deduped
+      packet.brokerId = null
+      client.deliverQoS(packet, cb)
+    }))
   }
-  var stream = persistence.createRetainedStreamCombi(topics)
-  stream.pipe(through.obj(function sendRetained (packet, enc, cb) {
-    packet = new Packet({
-      cmd: packet.cmd,
-      qos: packet.qos,
-      topic: packet.topic,
-      payload: packet.payload,
-      retain: true
-    }, broker)
-    // this should not be deduped
-    packet.brokerId = null
-    client.deliverQoS(packet, cb)
-  }))
 }
 
 function nop () {}


### PR DESCRIPTION
For issue https://github.com/mcollina/aedes/issues/300, and probably for issue https://github.com/mcollina/aedes/issues/126

Based on MQTT Spec section 3.1.2.4, we should not send retained messages when we restore subscriptions with clean=false clients.