### PR TITLE
Proxy and ip decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Options:
   packet to arrive, defaults to `30000` milliseconds
 * `id`: id used to identify this broker instance in `$SYS` messages,
   defaults to `uuidv4()`
+* `decodeProtocol`: function called when a valid buffer is received, see
+  [instance.decodeProtocol()](#decodeProtocol)
 * `preConnect`: function called when a valid CONNECT is received, see
   [instance.preConnect()](#preConnect)
 * `authenticate`: function used to authenticate clients, see
@@ -220,7 +222,19 @@ Both `topic` and `payload` can be `Buffer` objects instead of strings.
 ### instance.unsubscribe(topic, func(packet, cb), done)
 
 The reverse of [subscribe](#subscribe).
+------------------------------------------------------
+<a name="decodeProtocol"></a>
+### instance.decodeProtocol(client, buffer)
 
+It will be called when aedes instance trustProxy is true and that it receives a first valid buffer from client. client object state is in default and its connected state is false. A default function parse https headers (x-real-ip | x-forwarded-for) and proxy protocol v1 and v2 to retrieve information in client.connDetails. Override to supply custom protocolDecoder logic, if it returns an object with data property, this property will be parsed as an mqtt-packet.
+
+
+```js
+instance.decodeProtocol = function(client, buffer) {
+  var protocol = yourDecoder(client, buffer)
+  return protocol
+}
+```
 -------------------------------------------------------
 <a name="preConnect"></a>
 ### instance.preConnect(client, done(err, successful))

--- a/aedes.js
+++ b/aedes.js
@@ -11,6 +11,7 @@ var Packet = require('aedes-packet')
 var bulk = require('bulk-write-stream')
 var reusify = require('reusify')
 var Client = require('./lib/client')
+var protocolDecoder = require('./lib/protocol-decoder')
 
 module.exports = Aedes
 Aedes.Server = Aedes
@@ -19,6 +20,7 @@ var defaultOptions = {
   concurrency: 100,
   heartbeatInterval: 60000, // 1 minute
   connectTimeout: 30000, // 30 secs
+  decodeProtocol: defaultDecodeProtocol,
   preConnect: defaultPreConnect,
   authenticate: defaultAuthenticate,
   authorizePublish: defaultAuthorizePublish,
@@ -60,6 +62,8 @@ function Aedes (opts) {
   this.authorizeSubscribe = opts.authorizeSubscribe
   this.authorizeForward = opts.authorizeForward
   this.published = opts.published
+
+  this.decodeProtocol = opts.decodeProtocol
   this.trustProxy = opts.trustProxy
   this.trustedProxies = opts.trustedProxies
 
@@ -299,9 +303,15 @@ Aedes.prototype.close = function (cb = noop) {
 
 Aedes.prototype.version = require('./package.json').version
 
+function defaultDecodeProtocol (client, buffer) {
+  var proto = protocolDecoder(client, buffer)
+  return proto
+}
+
 function defaultPreConnect (client, callback) {
   callback(null, true)
 }
+
 function defaultAuthenticate (client, username, password, callback) {
   callback(null, true)
 }

--- a/aedes.js
+++ b/aedes.js
@@ -60,8 +60,7 @@ function Aedes (opts) {
   this.authorizeSubscribe = opts.authorizeSubscribe
   this.authorizeForward = opts.authorizeForward
   this.published = opts.published
-
-  this.trustProxy =  opts.trustProxy
+  this.trustProxy = opts.trustProxy
   this.trustedProxies = opts.trustedProxies
 
   this.clients = {}

--- a/aedes.js
+++ b/aedes.js
@@ -24,7 +24,9 @@ var defaultOptions = {
   authorizePublish: defaultAuthorizePublish,
   authorizeSubscribe: defaultAuthorizeSubscribe,
   authorizeForward: defaultAuthorizeForward,
-  published: defaultPublished
+  published: defaultPublished,
+  trustProxy: false,
+  trustedProxies: []
 }
 
 function Aedes (opts) {
@@ -58,6 +60,9 @@ function Aedes (opts) {
   this.authorizeSubscribe = opts.authorizeSubscribe
   this.authorizeForward = opts.authorizeForward
   this.published = opts.published
+
+  this.trustProxy =  opts.trustProxy
+  this.trustedProxies = opts.trustedProxies
 
   this.clients = {}
   this.brokers = {}

--- a/examples/proxy/index.js
+++ b/examples/proxy/index.js
@@ -1,102 +1,130 @@
+var aedes = require('../../aedes')
 var mqemitter = require('mqemitter')
 var persistence = require('aedes-persistence')
 var mqttPacket = require('mqtt-packet')
 var net = require('net')
 var proxyProtocol = require('proxy-protocol-js')
 
-function sendProxyPacket () {
+function sendProxyPacket (version = 1) {
   var packet = {
     cmd: 'connect',
     protocolId: 'MQTT',
     protocolVersion: 4,
     clean: true,
-    clientId: 'my-client',
+    clientId: `my-client-${version}`,
     keepalive: 0
   }
 
-  var data = mqttPacket.generate(packet)
-  console.log(data)
+  var protocol
+  if (version === 1) {
+    var src = new proxyProtocol.Peer('127.0.0.1', 12345)
+    var dst = new proxyProtocol.Peer('127.0.0.1', 1883)
+    protocol = new proxyProtocol.V1BinaryProxyProtocol(
+      proxyProtocol.INETProtocol.TCP4,
+      src,
+      dst,
+      mqttPacket.generate(packet)
+    ).build()
+  } else if (version === 2) {
+    protocol = new proxyProtocol.V2ProxyProtocol(
+      proxyProtocol.Command.LOCAL,
+      proxyProtocol.TransportProtocol.DGRAM,
+      new proxyProtocol.IPv4ProxyAddress(
+        proxyProtocol.IPv4Address.createFrom([127, 0, 0, 1]),
+        12346,
+        proxyProtocol.IPv4Address.createFrom([127, 0, 0, 1]),
+        1883
+      ),
+      mqttPacket.generate(packet)
+    ).build()
+  }
 
-  var src = new proxyProtocol.Peer('127.0.0.1', 12345)
-  var dst = new proxyProtocol.Peer('127.0.0.1', 1883)
-  var protocol = new proxyProtocol.V1BinaryProxyProtocol(
-    proxyProtocol.INETProtocol.TCP4,
-    src,
-    dst,
-    data
-  ).build()
+  var parsedProto = version === 1
+    ? proxyProtocol.V1BinaryProxyProtocol.parse(protocol)
+    : proxyProtocol.V2ProxyProtocol.parse(protocol)
+  // console.log(parsedProto)
 
-  console.log(protocol)
+  var dstPort = version === 1
+    ? parsedProto.destination.port
+    : parsedProto.proxyAddress.destinationPort
 
-  var parsedProto = proxyProtocol.V1BinaryProxyProtocol.parse(protocol)
-  console.log(parsedProto)
+  var dstHost = version === 1
+    ? parsedProto.destination.ipAddress
+    : parsedProto.proxyAddress.destinationAddress.address.join('.')
 
+  // console.log('Connection to :', dstHost, dstPort)
   var mqttConn = net.createConnection(
     {
-      port: parsedProto.destination.port,
-      host: parsedProto.destination.ipAddress,
-      // localAddress: proto.source.ipAddress,
-      // localPort: proto.source.port,
-      // family: parsedProto.ipFamily,
-      // lookup,
+      port: dstPort,
+      host: dstHost,
       timeout: 300
     }
   )
 
+  var data
+  if (version === 2) {
+    data = Buffer.from(protocol.buffer)
+  } else {
+    data = protocol
+  }
+
   mqttConn.on('timeout', function () {
-    mqttConn.write(protocol)
-    mqttConn.end()
+    // console.log("protocol proxy buffer", data)
+    mqttConn.write(data, () => {
+      mqttConn.end()
+    })
   })
 }
 
 function startAedes () {
   var port = 1883
 
-  var aedes = require('aedes')({
+  var broker = aedes({
     mq: mqemitter({
       concurrency: 100
     }),
     persistence: persistence(),
     preConnect: function (client, done) {
-      // check client.ipAddress
       console.log('Aedes preConnect check client ip:', client.ipAddress)
       client.ip = client.ipAddress
-      return done()
+      client.close()
+      return done(null, true)
     },
     trustProxy: true
   })
 
-  var server = require('net').createServer(aedes.handle)
+  var server = require('net').createServer(broker.handle)
 
   server.listen(port, function () {
     console.log('Aedes listening on port:', port)
-    aedes.publish({ topic: 'aedes/hello', payload: "I'm broker " + aedes.id })
-    sendProxyPacket()
+    broker.publish({ topic: 'aedes/hello', payload: "I'm broker " + broker.id })
+    setTimeout(() => sendProxyPacket(1), 250)
+    setTimeout(() => sendProxyPacket(2), 500)
   })
 
-  aedes.on('subscribe', function (subscriptions, client) {
+  broker.on('subscribe', function (subscriptions, client) {
     console.log('MQTT client \x1b[32m' + (client ? client.id : client) +
-            '\x1b[0m subscribed to topics: ' + subscriptions.map(s => s.topic).join('\n'), 'from broker', aedes.id)
+            '\x1b[0m subscribed to topics: ' + subscriptions.map(s => s.topic).join('\n'), 'from broker', broker.id)
   })
 
-  aedes.on('unsubscribe', function (subscriptions, client) {
+  broker.on('unsubscribe', function (subscriptions, client) {
     console.log('MQTT client \x1b[32m' + (client ? client.id : client) +
-            '\x1b[0m unsubscribed to topics: ' + subscriptions.join('\n'), 'from broker', aedes.id)
+            '\x1b[0m unsubscribed to topics: ' + subscriptions.join('\n'), 'from broker', broker.id)
   })
 
   // fired when a client connects
-  aedes.on('client', function (client) {
-    console.log('Client Connected: \x1b[33m' + (client ? client.id : client) + '-' + (client ? client.ipAddress : null) + '\x1b[0m', 'to broker', aedes.id)
+  broker.on('client', function (client) {
+    console.log('Client Connected: \x1b[33m' + (client ? client.id : client) + ' ip  ' + (client ? client.ip : null) + '\x1b[0m', 'to broker', broker.id)
   })
 
   // fired when a client disconnects
-  aedes.on('clientDisconnect', function (client) {
-    console.log('Client Disconnected: \x1b[31m' + (client ? client.id : client) + '\x1b[0m', 'to broker', aedes.id)
+  broker.on('clientDisconnect', function (client) {
+    console.log('Client Disconnected: \x1b[31m' + (client ? client.id : client) + '\x1b[0m', 'to broker', broker.id)
   })
 
   // fired when a message is published
-  aedes.on('publish', async function (packet, client) {
-    console.log('Client \x1b[31m' + (client ? client.id : 'BROKER_' + aedes.id) + '\x1b[0m has published', packet.payload.toString(), 'on', packet.topic, 'to broker', aedes.id)
+  broker.on('publish', async function (packet, client) {
+    console.log('Client \x1b[31m' + (client ? client.id : 'BROKER_' + broker.id) + '\x1b[0m has published', packet.payload.toString(), 'on', packet.topic, 'to broker', broker.id)
   })
 }
 

--- a/examples/proxy/index.js
+++ b/examples/proxy/index.js
@@ -1,0 +1,103 @@
+var mqemitter = require('mqemitter')
+var persistence = require('aedes-persistence')
+var mqttPacket = require('mqtt-packet')
+var net = require('net')
+var proxyProtocol = require('proxy-protocol-js')
+
+function sendProxyPacket () {
+  var packet = {
+    cmd: 'connect',
+    protocolId: 'MQTT',
+    protocolVersion: 4,
+    clean: true,
+    clientId: 'my-client',
+    keepalive: 0
+  }
+
+  var data = mqttPacket.generate(packet)
+  console.log(data)
+
+  var src = new proxyProtocol.Peer('127.0.0.1', 12345)
+  var dst = new proxyProtocol.Peer('127.0.0.1', 1883)
+  var protocol = new proxyProtocol.V1BinaryProxyProtocol(
+    proxyProtocol.INETProtocol.TCP4,
+    src,
+    dst,
+    data
+  ).build()
+
+  console.log(protocol)
+
+  var parsedProto = proxyProtocol.V1BinaryProxyProtocol.parse(protocol)
+  console.log(parsedProto)
+
+  var mqttConn = net.createConnection(
+    {
+      port: parsedProto.destination.port,
+      host: parsedProto.destination.ipAddress,
+      // localAddress: proto.source.ipAddress,
+      // localPort: proto.source.port,
+      // family: parsedProto.ipFamily,
+      // lookup,
+      timeout: 300
+    }
+  )
+
+  mqttConn.on('timeout', function () {
+    mqttConn.write(protocol)
+    mqttConn.end()
+  })
+}
+
+function startAedes () {
+  var port = 1883
+
+  var aedes = require('aedes')({
+    mq: mqemitter({
+      concurrency: 100
+    }),
+    persistence: persistence(),
+    preConnect: function (client, done) {
+      // check client.ipAddress
+      console.log('Aedes preConnect check client ip:', client.ipAddress)
+      client.ip = client.ipAddress
+      return done()
+    },
+    trustProxy: true
+  })
+
+  var server = require('net').createServer(aedes.handle)
+
+  server.listen(port, function () {
+    console.log('Aedes listening on port:', port)
+    aedes.publish({ topic: 'aedes/hello', payload: "I'm broker " + aedes.id })
+    sendProxyPacket()
+  })
+
+  aedes.on('subscribe', function (subscriptions, client) {
+    console.log('MQTT client \x1b[32m' + (client ? client.id : client) +
+            '\x1b[0m subscribed to topics: ' + subscriptions.map(s => s.topic).join('\n'), 'from broker', aedes.id)
+  })
+
+  aedes.on('unsubscribe', function (subscriptions, client) {
+    console.log('MQTT client \x1b[32m' + (client ? client.id : client) +
+            '\x1b[0m unsubscribed to topics: ' + subscriptions.join('\n'), 'from broker', aedes.id)
+  })
+
+  // fired when a client connects
+  aedes.on('client', function (client) {
+    console.log('Client Connected: \x1b[33m' + (client ? client.id : client) + '-' + (client ? client.ipAddress : null) + '\x1b[0m', 'to broker', aedes.id)
+  })
+
+  // fired when a client disconnects
+  aedes.on('clientDisconnect', function (client) {
+    console.log('Client Disconnected: \x1b[31m' + (client ? client.id : client) + '\x1b[0m', 'to broker', aedes.id)
+  })
+
+  // fired when a message is published
+  aedes.on('publish', async function (packet, client) {
+    console.log('Client \x1b[31m' + (client ? client.id : 'BROKER_' + aedes.id) + '\x1b[0m has published', packet.payload.toString(), 'on', packet.topic, 'to broker', aedes.id)
+  })
+}
+
+startAedes()

--- a/examples/proxy/index.js
+++ b/examples/proxy/index.js
@@ -112,11 +112,6 @@ function sendProxyPacket (version = 1, ipFamily = 4) {
   )
 
   var data = protocol
-  // if (!Buffer.isBuffer(protocol)) {
-  //   data = Buffer.from(protocol.buffer)
-  // } else {
-  //   data = protocol
-  // }
 
   mqttConn.on('timeout', function () {
     mqttConn.end(data)

--- a/examples/proxy/index.js
+++ b/examples/proxy/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var aedes = require('../../aedes')
 var mqemitter = require('mqemitter')
 var persistence = require('aedes-persistence')
@@ -57,7 +59,7 @@ function sendProxyPacket (version = 1) {
     {
       port: dstPort,
       host: dstHost,
-      timeout: 300
+      timeout: 150
     }
   )
 
@@ -85,8 +87,10 @@ function startAedes () {
     }),
     persistence: persistence(),
     preConnect: function (client, done) {
-      console.log('Aedes preConnect check client ip:', client.ipAddress)
-      client.ip = client.ipAddress
+      console.log('Aedes preConnect check client ip:', client.connDetails)
+      if (client.connDetails && client.connDetails.ipAddress) {
+        client.ip = client.connDetails.ipAddress
+      }
       client.close()
       return done(null, true)
     },

--- a/examples/proxy/package.json
+++ b/examples/proxy/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "aedes_proxy",
+  "version": "1.0.0",
+  "description": "Testing Aedes Broker behing proxy",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "getlarge",
+  "license": "MIT",
+  "dependencies": {
+    "aedes": "git+https://git@github.com/getlarge/aedes.git#proxy_and_ip_decoder",
+    "mqemitter": "^3.0.0",
+    "mqtt-packet": "^6.2.1",
+    "proxy-protocol-js": "^4.0.2"
+  }
+}

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,6 +6,7 @@ var util = require('util')
 var eos = require('end-of-stream')
 var empty = Buffer.allocUnsafe(0)
 var Packet = require('aedes-packet')
+var { V1BinaryProxyProtocol, V2ProxyProtocol } = require('proxy-protocol-js');
 var write = require('./write')
 var QoSPacket = require('./qos-packet')
 var handleSubscribe = require('./handlers/subscribe')
@@ -45,7 +46,82 @@ function Client (broker, conn, req) {
 
   this.disconnected = false
 
+  this.ipAddress = null
+  this.ipFamily = null
+  this.isWebsocket = false
+  this.isProxied = false
+
   this.parser.on('packet', enqueue)
+
+  function protocolDecoder(data) {
+    var proto = {}
+    if (!data) return proto
+    // todo: checkProxiesList(that.conn, that.broker.trustedProxies)
+    var trustProxy = that.broker.trustProxy
+    var ipFamily
+    var conn = that.conn
+    var socket = conn.socket || conn
+    var headers = that.req && that.req.headers ? that.req.headers : null
+    // console.log('CONN ADDRESS', conn.address())
+    if (trustProxy && headers) {
+      // console.log('PROXY HTTP HEADERS', headers)
+      if (headers["x-real-ip"] ) proto.ipAddress = headers["x-real-ip"]
+      else if (headers["x-forwarded-for"] ) proto.ipAddress = headers["x-forwarded-for"]
+      // console.log('WEB SOCKET VIA PROXY', proto.ipAddress)
+      that.isWebsocket = true
+      that.isProxied = true
+    } else if (trustProxy) {
+      var proxyProto
+      try {
+        // used by nginx
+        proxyProto = V1BinaryProxyProtocol.parse(data)
+        // console.log('PROXY PROTOCOL V1', proxyProto)
+      } catch (V1BinaryProxyProtocolE) {
+        try {
+          // used by AWS NLB
+          proxyProto = V2ProxyProtocol.parse(data)
+          // console.log('PROXY PROTOCOL V2', proxyProto)
+        } catch (V2ProxyProtocolE) {
+          // empty;
+        }
+      } finally {
+        if (proxyProto && proxyProto.source && proxyProto.data) {
+          ipFamily = proxyProto.inetProtocol
+          proto.ipAddress = proxyProto.source.ipAddress
+          proto.data = proxyProto.data
+          that.isWebsocket = false
+          that.isProxied = true
+          // console.log('TCP SOCKET VIA PROXY', proto.ipAddress)
+        }
+      }
+    } 
+
+    if (!proto.ipAddress) {
+      if (socket._socket && socket._socket.address) {
+        that.isWebsocket = true
+        that.isProxied = false
+        proto.ipAddress = socket._socket.remoteAddress
+        ipFamily = socket._socket.remoteFamily
+        // console.log('WEBSOCKET ADDRESS', proto.ipAddress)
+      } else if (socket.address) {
+        proto.ipAddress = socket.remoteAddress
+        ipFamily = socket.remoteFamily
+        that.isWebsocket = false
+        that.isProxied = false
+        // console.log('TCPSOCKET ADDRESS', proto.ipAddress)
+      }
+    }
+     
+    if (ipFamily && ipFamily.endsWith('4')) {
+      proto.ipFamily = 4;
+    } else if (ipFamily && ipFamily.endsWith('6')) {
+      proto.ipFamily = 6;
+    } else {
+      proto.ipFamily = 0;
+    }  
+    // console.log('proxy decoder res ', Object.keys(proto))
+    return proto
+  }
 
   function nextBatch (err) {
     if (err) {
@@ -64,8 +140,11 @@ function Client (broker, conn, req) {
       that._parsingBatch = 0
       var buf = empty
       buf = client.conn.read(null)
-
-      if (buf) {
+      var {ipFamily, ipAddress, data} = protocolDecoder(buf)
+      if (ipAddress) client.ipAddress = ipAddress
+      if (data) {
+        client.parser.parse(data)
+      } else if (buf) {
         client.parser.parse(buf)
       }
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,7 +6,6 @@ var util = require('util')
 var eos = require('end-of-stream')
 var empty = Buffer.allocUnsafe(0)
 var Packet = require('aedes-packet')
-var proxyProtocol = require('proxy-protocol-js')
 var write = require('./write')
 var QoSPacket = require('./qos-packet')
 var handleSubscribe = require('./handlers/subscribe')
@@ -46,88 +45,9 @@ function Client (broker, conn, req) {
 
   this.disconnected = false
 
-  this.ipAddress = null
-  this.ipFamily = null
-  this.isWebsocket = false
-  this.isProxied = false
+  this.connDetails = {}
 
   this.parser.on('packet', enqueue)
-
-  function protocolDecoder (data) {
-    var proto = {}
-    if (!data) return proto
-    // todo: checkProxiesList(that.conn, that.broker.trustedProxies)
-    var trustProxy = that.broker.trustProxy
-    var ipFamily
-    var conn = that.conn
-    var socket = conn.socket || conn
-    var headers = that.req && that.req.headers ? that.req.headers : null
-    if (trustProxy && headers) {
-      // console.log('PROXY HTTP HEADERS', headers)
-      if (headers['x-real-ip']) proto.ipAddress = headers['x-real-ip']
-      else if (headers['x-forwarded-for']) proto.ipAddress = headers['x-forwarded-for']
-      // console.log('WEB SOCKET VIA PROXY', proto.ipAddress)
-      that.isWebsocket = true
-      that.isProxied = true
-    } else if (trustProxy) {
-      var proxyProto
-      try {
-        proxyProto = proxyProtocol.V1BinaryProxyProtocol.parse(data)
-        // console.log('PROXY PROTOCOL V1', proxyProto)
-      } catch (V1BinaryProxyProtocolE) {
-        try {
-          proxyProto = proxyProtocol.V2ProxyProtocol.parse(data)
-          // console.log('PROXY PROTOCOL V2', proxyProto)
-        } catch (V2ProxyProtocolE) {
-          // empty;
-        }
-      } finally {
-        if (proxyProto && proxyProto.source && proxyProto.data) {
-          ipFamily = proxyProto.inetProtocol
-          proto.ipAddress = proxyProto.source.ipAddress
-          proto.data = proxyProto.data
-          that.isWebsocket = false
-          that.isProxied = true
-          // console.log('TCP SOCKET VIA PROXY V1', proto.ipAddress)
-        } else if (proxyProto && proxyProto.proxyAddress && proxyProto.data) {
-          if (proxyProto.proxyAddress instanceof proxyProtocol.IPv4ProxyAddress) {
-            ipFamily = 'IPv4'
-          } else if (proxyProto.proxyAddress instanceof proxyProtocol.IPv6ProxyAddress) {
-            ipFamily = 'IPv6'
-          }
-          proto.ipAddress = proxyProto.proxyAddress.sourceAddress.address.join('.')
-          proto.data = proxyProto.data
-          // proto.data = Buffer.from(proxyProto.data)
-          that.isWebsocket = false
-          that.isProxied = true
-          // console.log('TCP SOCKET VIA PROXY V2', proto.ipAddress)
-        }
-      }
-    }
-    if (!proto.ipAddress) {
-      if (socket._socket && socket._socket.address) {
-        that.isWebsocket = true
-        that.isProxied = false
-        proto.ipAddress = socket._socket.remoteAddress
-        ipFamily = socket._socket.remoteFamily
-        // console.log('WEBSOCKET ADDRESS', proto.ipAddress)
-      } else if (socket.address) {
-        proto.ipAddress = socket.remoteAddress
-        ipFamily = socket.remoteFamily
-        that.isWebsocket = false
-        that.isProxied = false
-        // console.log('TCPSOCKET ADDRESS', proto.ipAddress)
-      }
-    }
-    if (ipFamily && ipFamily.endsWith('4')) {
-      proto.ipFamily = 4
-    } else if (ipFamily && ipFamily.endsWith('6')) {
-      proto.ipFamily = 6
-    } else {
-      proto.ipFamily = 0
-    }
-    return proto
-  }
 
   function nextBatch (err) {
     if (err) {
@@ -146,11 +66,13 @@ function Client (broker, conn, req) {
       that._parsingBatch = 0
       var buf = empty
       buf = client.conn.read(null)
-      var { ipFamily, ipAddress, data } = protocolDecoder(buf)
-      if (ipAddress) client.ipAddress = ipAddress
-      if (ipFamily) client.ipFamily = ipFamily
-      if (data) {
-        client.parser.parse(data)
+      if (!client.connackSent && client.broker.trustProxy && buf) {
+        var { data } = client.broker.decodeProtocol(client, buf)
+        if (data) {
+          client.parser.parse(data)
+        } else {
+          client.parser.parse(buf)
+        }
       } else if (buf) {
         client.parser.parse(buf)
       }

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,7 +6,7 @@ var util = require('util')
 var eos = require('end-of-stream')
 var empty = Buffer.allocUnsafe(0)
 var Packet = require('aedes-packet')
-var { V1BinaryProxyProtocol, V2ProxyProtocol } = require('proxy-protocol-js')
+var proxyProtocol = require('proxy-protocol-js')
 var write = require('./write')
 var QoSPacket = require('./qos-packet')
 var handleSubscribe = require('./handlers/subscribe')
@@ -62,7 +62,6 @@ function Client (broker, conn, req) {
     var conn = that.conn
     var socket = conn.socket || conn
     var headers = that.req && that.req.headers ? that.req.headers : null
-    // console.log('CONN ADDRESS', conn.address())
     if (trustProxy && headers) {
       // console.log('PROXY HTTP HEADERS', headers)
       if (headers['x-real-ip']) proto.ipAddress = headers['x-real-ip']
@@ -73,13 +72,11 @@ function Client (broker, conn, req) {
     } else if (trustProxy) {
       var proxyProto
       try {
-        // used by nginx
-        proxyProto = V1BinaryProxyProtocol.parse(data)
+        proxyProto = proxyProtocol.V1BinaryProxyProtocol.parse(data)
         // console.log('PROXY PROTOCOL V1', proxyProto)
       } catch (V1BinaryProxyProtocolE) {
         try {
-          // used by AWS NLB
-          proxyProto = V2ProxyProtocol.parse(data)
+          proxyProto = proxyProtocol.V2ProxyProtocol.parse(data)
           // console.log('PROXY PROTOCOL V2', proxyProto)
         } catch (V2ProxyProtocolE) {
           // empty;
@@ -91,7 +88,19 @@ function Client (broker, conn, req) {
           proto.data = proxyProto.data
           that.isWebsocket = false
           that.isProxied = true
-          // console.log('TCP SOCKET VIA PROXY', proto.ipAddress)
+          // console.log('TCP SOCKET VIA PROXY V1', proto.ipAddress)
+        } else if (proxyProto && proxyProto.proxyAddress && proxyProto.data) {
+          if (proxyProto.proxyAddress instanceof proxyProtocol.IPv4ProxyAddress) {
+            ipFamily = 'IPv4'
+          } else if (proxyProto.proxyAddress instanceof proxyProtocol.IPv6ProxyAddress) {
+            ipFamily = 'IPv6'
+          }
+          proto.ipAddress = proxyProto.proxyAddress.sourceAddress.address.join('.')
+          proto.data = proxyProto.data
+          // proto.data = Buffer.from(proxyProto.data)
+          that.isWebsocket = false
+          that.isProxied = true
+          // console.log('TCP SOCKET VIA PROXY V2', proto.ipAddress)
         }
       }
     }
@@ -117,7 +126,6 @@ function Client (broker, conn, req) {
     } else {
       proto.ipFamily = 0
     }
-    // console.log('proxy decoder res ', Object.keys(proto))
     return proto
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,7 +6,7 @@ var util = require('util')
 var eos = require('end-of-stream')
 var empty = Buffer.allocUnsafe(0)
 var Packet = require('aedes-packet')
-var { V1BinaryProxyProtocol, V2ProxyProtocol } = require('proxy-protocol-js');
+var { V1BinaryProxyProtocol, V2ProxyProtocol } = require('proxy-protocol-js')
 var write = require('./write')
 var QoSPacket = require('./qos-packet')
 var handleSubscribe = require('./handlers/subscribe')
@@ -53,7 +53,7 @@ function Client (broker, conn, req) {
 
   this.parser.on('packet', enqueue)
 
-  function protocolDecoder(data) {
+  function protocolDecoder (data) {
     var proto = {}
     if (!data) return proto
     // todo: checkProxiesList(that.conn, that.broker.trustedProxies)
@@ -65,8 +65,8 @@ function Client (broker, conn, req) {
     // console.log('CONN ADDRESS', conn.address())
     if (trustProxy && headers) {
       // console.log('PROXY HTTP HEADERS', headers)
-      if (headers["x-real-ip"] ) proto.ipAddress = headers["x-real-ip"]
-      else if (headers["x-forwarded-for"] ) proto.ipAddress = headers["x-forwarded-for"]
+      if (headers['x-real-ip']) proto.ipAddress = headers['x-real-ip']
+      else if (headers['x-forwarded-for']) proto.ipAddress = headers['x-forwarded-for']
       // console.log('WEB SOCKET VIA PROXY', proto.ipAddress)
       that.isWebsocket = true
       that.isProxied = true
@@ -94,8 +94,7 @@ function Client (broker, conn, req) {
           // console.log('TCP SOCKET VIA PROXY', proto.ipAddress)
         }
       }
-    } 
-
+    }
     if (!proto.ipAddress) {
       if (socket._socket && socket._socket.address) {
         that.isWebsocket = true
@@ -111,14 +110,13 @@ function Client (broker, conn, req) {
         // console.log('TCPSOCKET ADDRESS', proto.ipAddress)
       }
     }
-     
     if (ipFamily && ipFamily.endsWith('4')) {
-      proto.ipFamily = 4;
+      proto.ipFamily = 4
     } else if (ipFamily && ipFamily.endsWith('6')) {
-      proto.ipFamily = 6;
+      proto.ipFamily = 6
     } else {
-      proto.ipFamily = 0;
-    }  
+      proto.ipFamily = 0
+    }
     // console.log('proxy decoder res ', Object.keys(proto))
     return proto
   }
@@ -140,8 +138,9 @@ function Client (broker, conn, req) {
       that._parsingBatch = 0
       var buf = empty
       buf = client.conn.read(null)
-      var {ipFamily, ipAddress, data} = protocolDecoder(buf)
+      var { ipFamily, ipAddress, data } = protocolDecoder(buf)
       if (ipAddress) client.ipAddress = ipAddress
+      if (ipFamily) client.ipFamily = ipFamily
       if (data) {
         client.parser.parse(data)
       } else if (buf) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -45,7 +45,7 @@ function Client (broker, conn, req) {
 
   this.disconnected = false
 
-  this.connDetails = {}
+  this.connDetails = null
 
   this.parser.on('packet', enqueue)
 

--- a/lib/protocol-decoder.js
+++ b/lib/protocol-decoder.js
@@ -49,7 +49,6 @@ function parseIpV6Array (ip) {
 function protocolDecoder (client, data) {
   var proto = {}
   if (!data) return proto
-  // todo: checkProxiesList(client.conn, client.broker.trustedProxies)
   var trustProxy = client.broker.trustProxy
   var ipFamily
   var conn = client.conn
@@ -62,6 +61,7 @@ function protocolDecoder (client, data) {
     if (headers) {
       if (headers['x-real-ip']) proto.ipAddress = headers['x-real-ip']
       else if (headers['x-forwarded-for']) proto.ipAddress = headers['x-forwarded-for']
+      proto.port = socket._socket.remotePort
       proto.isWebsocket = true
     }
     if (isValidV1ProxyProtocol(data)) {
@@ -69,6 +69,7 @@ function protocolDecoder (client, data) {
       if (proxyProto && proxyProto.source && proxyProto.data) {
         ipFamily = proxyProto.inetProtocol
         proto.ipAddress = proxyProto.source.ipAddress
+        proto.port = proxyProto.source.port
         proto.data = proxyProto.data
         proto.isProxy = 1
       }
@@ -78,9 +79,11 @@ function protocolDecoder (client, data) {
         if (proxyProto.proxyAddress instanceof proxyProtocol.IPv4ProxyAddress) {
           ipFamily = 'IPv4'
           proto.ipAddress = proxyProto.proxyAddress.sourceAddress.address.join('.')
+          proto.port = proxyProto.proxyAddress.sourceAddress.address.port
         } else if (proxyProto.proxyAddress instanceof proxyProtocol.IPv6ProxyAddress) {
           ipFamily = 'IPv6'
           proto.ipAddress = parseIpV6Array(proxyProto.proxyAddress.sourceAddress.address)
+          proto.port = proxyProto.proxyAddress.sourceAddress.address.port
         }
         proto.isProxy = 2
         if (Buffer.isBuffer(proxyProto.data)) {
@@ -95,9 +98,11 @@ function protocolDecoder (client, data) {
     if (socket._socket && socket._socket.address) {
       proto.isWebsocket = true
       proto.ipAddress = socket._socket.remoteAddress
+      proto.port = socket._socket.remotePort
       ipFamily = socket._socket.remoteFamily
     } else if (socket.address) {
       proto.ipAddress = socket.remoteAddress
+      proto.port = socket.remotePort
       ipFamily = socket.remoteFamily
     }
   }
@@ -108,8 +113,12 @@ function protocolDecoder (client, data) {
   } else {
     proto.ipFamily = 0
   }
+  if (!client.connDetails) client.connDetails = {}
   if (proto.ipAddress) {
     client.connDetails.ipAddress = proto.ipAddress
+  }
+  if (proto.port) {
+    client.connDetails.port = proto.port
   }
   client.connDetails.ipFamily = proto.ipFamily
   client.connDetails.isProxy = proto.isProxy

--- a/lib/protocol-decoder.js
+++ b/lib/protocol-decoder.js
@@ -2,67 +2,92 @@
 
 var proxyProtocol = require('proxy-protocol-js')
 
+var v1ProxyProtocolSignature = Buffer.from('PROXY ', 'utf8')
+var v2ProxyProtocolSignature = Buffer.from([
+  0x0d,
+  0x0a,
+  0x0d,
+  0x0a,
+  0x00,
+  0x0d,
+  0x0a,
+  0x51,
+  0x55,
+  0x49,
+  0x54,
+  0x0a
+])
+
+function isValidV1ProxyProtocol (buffer) {
+  for (var i = 0; i < v1ProxyProtocolSignature.length; i++) {
+    if (buffer[i] !== v1ProxyProtocolSignature[i]) {
+      return false
+    }
+  }
+  return true
+}
+
+function isValidV2ProxyProtocol (buffer) {
+  for (var i = 0; i < v2ProxyProtocolSignature.length; i++) {
+    if (buffer[i] !== v2ProxyProtocolSignature[i]) {
+      return false
+    }
+  }
+  return true
+}
+
 function protocolDecoder (client, data) {
   var proto = {}
-  // var buffer = Buffer.allocUnsafe(0)
-  // buffer = client.conn.read(null)
   if (!data) return proto
   // todo: checkProxiesList(client.conn, client.broker.trustedProxies)
   var trustProxy = client.broker.trustProxy
   var ipFamily
   var conn = client.conn
   var socket = conn.socket || conn
-  var headers = client.req && client.req.headers ? client.req.headers : null
-  if (trustProxy && headers) {
-    if (headers['x-real-ip']) proto.ipAddress = headers['x-real-ip']
-    else if (headers['x-forwarded-for']) proto.ipAddress = headers['x-forwarded-for']
-    client.connDetails.isWebsocket = true
-    client.connDetails.isProxied = true
-  } else if (trustProxy) {
+  proto.isProxy = 0
+  proto.isWebsocket = false
+  if (trustProxy) {
+    var headers = client.req && client.req.headers ? client.req.headers : null
     var proxyProto
-    try {
+    if (headers) {
+      if (headers['x-real-ip']) proto.ipAddress = headers['x-real-ip']
+      else if (headers['x-forwarded-for']) proto.ipAddress = headers['x-forwarded-for']
+      proto.isWebsocket = true
+    }
+    if (isValidV1ProxyProtocol(data)) {
       proxyProto = proxyProtocol.V1BinaryProxyProtocol.parse(data)
-    } catch (V1BinaryProxyProtocolE) {
-      try {
-        proxyProto = proxyProtocol.V2ProxyProtocol.parse(data)
-      } catch (V2ProxyProtocolE) {
-        // empty;
-      }
-    } finally {
       if (proxyProto && proxyProto.source && proxyProto.data) {
         ipFamily = proxyProto.inetProtocol
         proto.ipAddress = proxyProto.source.ipAddress
         proto.data = proxyProto.data
-        client.connDetails.isWebsocket = false
-        client.connDetails.isProxied = true
-      } else if (proxyProto && proxyProto.proxyAddress && proxyProto.data) {
+        proto.isProxy = 1
+      }
+    } else if (isValidV2ProxyProtocol(data)) {
+      proxyProto = proxyProtocol.V2ProxyProtocol.parse(data)
+      if (proxyProto && proxyProto.proxyAddress && proxyProto.data) {
         if (proxyProto.proxyAddress instanceof proxyProtocol.IPv4ProxyAddress) {
           ipFamily = 'IPv4'
         } else if (proxyProto.proxyAddress instanceof proxyProtocol.IPv6ProxyAddress) {
           ipFamily = 'IPv6'
         }
         proto.ipAddress = proxyProto.proxyAddress.sourceAddress.address.join('.')
+        proto.isProxy = 2
         if (Buffer.isBuffer(proxyProto.data)) {
           proto.data = proxyProto.data
         } else {
           proto.data = Buffer.from(proxyProto.data)
         }
-        client.connDetails.isWebsocket = false
-        client.connDetails.isProxied = true
       }
     }
   }
   if (!proto.ipAddress) {
     if (socket._socket && socket._socket.address) {
-      client.connDetails.isWebsocket = true
-      client.connDetails.isProxied = false
+      proto.isWebsocket = true
       proto.ipAddress = socket._socket.remoteAddress
       ipFamily = socket._socket.remoteFamily
     } else if (socket.address) {
       proto.ipAddress = socket.remoteAddress
       ipFamily = socket.remoteFamily
-      client.connDetails.isWebsocket = false
-      client.connDetails.isProxied = false
     }
   }
   if (ipFamily && ipFamily.endsWith('4')) {
@@ -75,9 +100,8 @@ function protocolDecoder (client, data) {
   if (proto.ipAddress) {
     client.connDetails.ipAddress = proto.ipAddress
   }
-  if (proto.ipFamily !== undefined) {
-    client.connDetails.ipFamily = proto.ipFamily
-  }
+  client.connDetails.ipFamily = proto.ipFamily
+  client.connDetails.isProxy = proto.isProxy
   return proto
 }
 

--- a/lib/protocol-decoder.js
+++ b/lib/protocol-decoder.js
@@ -1,0 +1,84 @@
+'use strict'
+
+var proxyProtocol = require('proxy-protocol-js')
+
+function protocolDecoder (client, data) {
+  var proto = {}
+  // var buffer = Buffer.allocUnsafe(0)
+  // buffer = client.conn.read(null)
+  if (!data) return proto
+  // todo: checkProxiesList(client.conn, client.broker.trustedProxies)
+  var trustProxy = client.broker.trustProxy
+  var ipFamily
+  var conn = client.conn
+  var socket = conn.socket || conn
+  var headers = client.req && client.req.headers ? client.req.headers : null
+  if (trustProxy && headers) {
+    if (headers['x-real-ip']) proto.ipAddress = headers['x-real-ip']
+    else if (headers['x-forwarded-for']) proto.ipAddress = headers['x-forwarded-for']
+    client.connDetails.isWebsocket = true
+    client.connDetails.isProxied = true
+  } else if (trustProxy) {
+    var proxyProto
+    try {
+      proxyProto = proxyProtocol.V1BinaryProxyProtocol.parse(data)
+    } catch (V1BinaryProxyProtocolE) {
+      try {
+        proxyProto = proxyProtocol.V2ProxyProtocol.parse(data)
+      } catch (V2ProxyProtocolE) {
+        // empty;
+      }
+    } finally {
+      if (proxyProto && proxyProto.source && proxyProto.data) {
+        ipFamily = proxyProto.inetProtocol
+        proto.ipAddress = proxyProto.source.ipAddress
+        proto.data = proxyProto.data
+        client.connDetails.isWebsocket = false
+        client.connDetails.isProxied = true
+      } else if (proxyProto && proxyProto.proxyAddress && proxyProto.data) {
+        if (proxyProto.proxyAddress instanceof proxyProtocol.IPv4ProxyAddress) {
+          ipFamily = 'IPv4'
+        } else if (proxyProto.proxyAddress instanceof proxyProtocol.IPv6ProxyAddress) {
+          ipFamily = 'IPv6'
+        }
+        proto.ipAddress = proxyProto.proxyAddress.sourceAddress.address.join('.')
+        if (Buffer.isBuffer(proxyProto.data)) {
+          proto.data = proxyProto.data
+        } else {
+          proto.data = Buffer.from(proxyProto.data)
+        }
+        client.connDetails.isWebsocket = false
+        client.connDetails.isProxied = true
+      }
+    }
+  }
+  if (!proto.ipAddress) {
+    if (socket._socket && socket._socket.address) {
+      client.connDetails.isWebsocket = true
+      client.connDetails.isProxied = false
+      proto.ipAddress = socket._socket.remoteAddress
+      ipFamily = socket._socket.remoteFamily
+    } else if (socket.address) {
+      proto.ipAddress = socket.remoteAddress
+      ipFamily = socket.remoteFamily
+      client.connDetails.isWebsocket = false
+      client.connDetails.isProxied = false
+    }
+  }
+  if (ipFamily && ipFamily.endsWith('4')) {
+    proto.ipFamily = 4
+  } else if (ipFamily && ipFamily.endsWith('6')) {
+    proto.ipFamily = 6
+  } else {
+    proto.ipFamily = 0
+  }
+  if (proto.ipAddress) {
+    client.connDetails.ipAddress = proto.ipAddress
+  }
+  if (proto.ipFamily !== undefined) {
+    client.connDetails.ipFamily = proto.ipFamily
+  }
+  return proto
+}
+
+module.exports = protocolDecoder

--- a/lib/protocol-decoder.js
+++ b/lib/protocol-decoder.js
@@ -36,6 +36,16 @@ function isValidV2ProxyProtocol (buffer) {
   return true
 }
 
+// from https://stackoverflow.com/questions/57077161/how-do-i-convert-hex-buffer-to-ipv6-in-javascript
+function parseIpV6Array (ip) {
+  var ipHex = Buffer.from(ip).toString('hex')
+  return ipHex.match(/.{1,4}/g)
+    .map((val) => val.replace(/^0+/, ''))
+    .join(':')
+    .replace(/0000:/g, ':')
+    .replace(/:{2,}/g, '::')
+}
+
 function protocolDecoder (client, data) {
   var proto = {}
   if (!data) return proto
@@ -67,10 +77,11 @@ function protocolDecoder (client, data) {
       if (proxyProto && proxyProto.proxyAddress && proxyProto.data) {
         if (proxyProto.proxyAddress instanceof proxyProtocol.IPv4ProxyAddress) {
           ipFamily = 'IPv4'
+          proto.ipAddress = proxyProto.proxyAddress.sourceAddress.address.join('.')
         } else if (proxyProto.proxyAddress instanceof proxyProtocol.IPv6ProxyAddress) {
           ipFamily = 'IPv6'
+          proto.ipAddress = parseIpV6Array(proxyProto.proxyAddress.sourceAddress.address)
         }
-        proto.ipAddress = proxyProto.proxyAddress.sourceAddress.address.join('.')
         proto.isProxy = 2
         if (Buffer.isBuffer(proxyProto.data)) {
           proto.data = proxyProto.data
@@ -102,6 +113,7 @@ function protocolDecoder (client, data) {
   }
   client.connDetails.ipFamily = proto.ipFamily
   client.connDetails.isProxy = proto.isProxy
+  client.connDetails.isWebsocket = proto.isWebsocket
   return proto
 }
 

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "from2": "^2.3.0",
     "mqemitter": "^3.0.0",
     "mqtt-packet": "^6.2.1",
+    "proxy-protocol-js": "^4.0.2",
     "pump": "^3.0.0",
     "retimer": "^2.0.0",
     "reusify": "^1.0.4",

--- a/test/basic.js
+++ b/test/basic.js
@@ -160,11 +160,9 @@ test('unsubscribe on disconnect for a clean=true client', function (t) {
   t.plan(7)
 
   var opts = { clean: true }
-  // var s = noError(connect(setup(), opts), t)
   var s = connect(setup(), opts)
 
   subscribe(t, s, 'hello', 0, function () {
-    // s.conn.emit('close')
     s.conn.destroy(null, function () {
       t.pass('closed streams')
     })
@@ -192,11 +190,9 @@ test('unsubscribe on disconnect for a clean=false client', function (t) {
   t.plan(6)
 
   var opts = { clean: false }
-  // var s = noError(connect(setup(), opts), t)
   var s = connect(setup(), opts)
 
   subscribe(t, s, 'hello', 0, function () {
-    // s.conn.emit('close')
     s.conn.destroy(null, function () {
       t.pass('closed streams')
     })

--- a/test/basic.js
+++ b/test/basic.js
@@ -157,13 +157,17 @@ test('unsubscribe without subscribe', function (t) {
 })
 
 test('unsubscribe on disconnect for a clean=true client', function (t) {
-  t.plan(6)
+  t.plan(7)
 
   var opts = { clean: true }
-  var s = noError(connect(setup(), opts), t)
+  // var s = noError(connect(setup(), opts), t)
+  var s = connect(setup(), opts)
 
   subscribe(t, s, 'hello', 0, function () {
-    s.conn.emit('close')
+    // s.conn.emit('close')
+    s.conn.destroy(null, function () {
+      t.pass('closed streams')
+    })
     s.outStream.on('data', function () {
       t.fail('should not receive any more messages')
     })
@@ -185,13 +189,17 @@ test('unsubscribe on disconnect for a clean=true client', function (t) {
 })
 
 test('unsubscribe on disconnect for a clean=false client', function (t) {
-  t.plan(5)
+  t.plan(6)
 
   var opts = { clean: false }
-  var s = noError(connect(setup(), opts), t)
+  // var s = noError(connect(setup(), opts), t)
+  var s = connect(setup(), opts)
 
   subscribe(t, s, 'hello', 0, function () {
-    s.conn.emit('close')
+    // s.conn.emit('close')
+    s.conn.destroy(null, function () {
+      t.pass('closed streams')
+    })
     s.outStream.on('data', function () {
       t.fail('should not receive any more messages')
     })

--- a/test/connect.js
+++ b/test/connect.js
@@ -568,7 +568,7 @@ test('tcp proxied (protocol v2) clients have access to the ipAddress property', 
       port,
       timeout: 0
     }, function () {
-      client.write(protocol)
+      client.write(Buffer.from(protocol))
     }
   )
 

--- a/test/connect.js
+++ b/test/connect.js
@@ -420,8 +420,8 @@ test('websocket clients have access to the request object', function (t) {
   }
 })
 
-// test ipAddress property presence
-test('tcp clients have access to the ipAddress property', function (t) {
+// test ipAddress property presence when trustProxy is enabled
+test('tcp clients have access to the ipAddress from the socket', function (t) {
   t.plan(2)
 
   var port = 4883
@@ -459,8 +459,7 @@ test('tcp clients have access to the ipAddress property', function (t) {
   }
 })
 
-// mocking mqtt packet delivered by a proxy / load balancer using proxy protocol v1
-test('tcp proxied (protocol v1) clients have access to the ipAddress property', function (t) {
+test('tcp proxied (protocol v1) clients have access to the ipAddress(v4)', function (t) {
   t.plan(2)
 
   var port = 4883
@@ -518,8 +517,7 @@ test('tcp proxied (protocol v1) clients have access to the ipAddress property', 
   }
 })
 
-// mocking mqtt packet delivered by a proxy / load balancer using proxy protocol v2
-test('tcp proxied (protocol v2) clients have access to the ipAddress property', function (t) {
+test('tcp proxied (protocol v2) clients have access to the ipAddress(v4)', function (t) {
   t.plan(2)
 
   var port = 4883
@@ -580,7 +578,107 @@ test('tcp proxied (protocol v2) clients have access to the ipAddress property', 
   }
 })
 
-test('websocket proxied clients have access to the ipAddress property', function (t) {
+test('tcp proxied (protocol v2) clients have access to the ipAddress(v6)', function (t) {
+  t.plan(2)
+
+  var port = 4883
+  var clientIpArray = [0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 192, 168, 1, 128]
+  var clientIp = '::ffff:c0a8:180:'
+  var packet = {
+    cmd: 'connect',
+    protocolId: 'MQTT',
+    protocolVersion: 4,
+    clean: true,
+    clientId: 'my-client-proxyV2'
+  }
+
+  var protocol = new proxyProtocol.V2ProxyProtocol(
+    proxyProtocol.Command.PROXY,
+    proxyProtocol.TransportProtocol.STREAM,
+    new proxyProtocol.IPv6ProxyAddress(
+      proxyProtocol.IPv6Address.createFrom(clientIpArray),
+      12345,
+      proxyProtocol.IPv6Address.createWithEmptyAddress(),
+      port
+    ),
+    mqttPacket.generate(packet)
+  ).build()
+
+  var broker = aedes({
+    preConnect: function (client, done) {
+      if (client.connDetails && client.connDetails.ipAddress) {
+        client.ip = client.connDetails.ipAddress
+        t.equal(clientIp, client.ip)
+      } else {
+        t.fail('no ip address present')
+      }
+      done(null, true)
+      setImmediate(finish)
+    },
+    trustProxy: true
+  })
+
+  var server = net.createServer(broker.handle)
+  server.listen(port, function (err) {
+    t.error(err, 'no error')
+  })
+
+  var client = net.createConnection(
+    {
+      port,
+      timeout: 0
+    }, function () {
+      client.write(Buffer.from(protocol))
+    }
+  )
+
+  function finish () {
+    client.end()
+    broker.close()
+    server.close()
+    t.end()
+  }
+})
+
+test('websocket clients have access to the ipAddress from the socket (if no ip header)', function (t) {
+  t.plan(2)
+
+  var clientIp = '::ffff:127.0.0.1'
+  var port = 4883
+  var broker = aedes({
+    preConnect: function (client, done) {
+      if (client.connDetails && client.connDetails.ipAddress) {
+        client.ip = client.connDetails.ipAddress
+        t.equal(clientIp, client.ip)
+      } else {
+        t.fail('no ip address present')
+      }
+      done(null, true)
+      setImmediate(finish)
+    },
+    trustProxy: true
+  })
+
+  var server = http.createServer()
+  ws.createServer({
+    server: server
+  }, broker.handle)
+
+  server.listen(port, function (err) {
+    t.error(err, 'no error')
+  })
+
+  var client = mqtt.connect(`ws://localhost:${port}`)
+
+  function finish () {
+    broker.close()
+    server.close()
+    client.end()
+    t.end()
+  }
+})
+
+test('websocket proxied clients have access to the ipAddress from x-real-ip header', function (t) {
   t.plan(2)
 
   var clientIp = '192.168.0.140'
@@ -612,6 +710,50 @@ test('websocket proxied clients have access to the ipAddress property', function
     wsOptions: {
       headers: {
         'X-Real-Ip': clientIp
+      }
+    }
+  })
+
+  function finish () {
+    broker.close()
+    server.close()
+    client.end()
+    t.end()
+  }
+})
+
+test('websocket proxied clients have access to the ipAddress from x-forwarded-for header', function (t) {
+  t.plan(2)
+
+  var clientIp = '192.168.0.140'
+  var port = 4883
+  var broker = aedes({
+    preConnect: function (client, done) {
+      if (client.connDetails && client.connDetails.ipAddress) {
+        client.ip = client.connDetails.ipAddress
+        t.equal(clientIp, client.ip)
+      } else {
+        t.fail('no ip address present')
+      }
+      done(null, true)
+      setImmediate(finish)
+    },
+    trustProxy: true
+  })
+
+  var server = http.createServer()
+  ws.createServer({
+    server: server
+  }, broker.handle)
+
+  server.listen(port, function (err) {
+    t.error(err, 'no error')
+  })
+
+  var client = mqtt.connect(`ws://localhost:${port}`, {
+    wsOptions: {
+      headers: {
+        'X-Forwarded-For': clientIp
       }
     }
   })

--- a/test/meta.js
+++ b/test/meta.js
@@ -26,7 +26,9 @@ test('count connected clients', function (t) {
 
       // needed because destroy() will do the trick before
       // the next tick
-      process.nextTick(function () {
+      // replaced process.nextTick with setImmediate,
+      // before there were still 2 clients connected after the tick, is this fix wrong ?
+      setImmediate(function () {
         t.equal(broker.connectedClients, 1, 'one connected clients')
       })
     })

--- a/test/meta.js
+++ b/test/meta.js
@@ -26,8 +26,6 @@ test('count connected clients', function (t) {
 
       // needed because destroy() will do the trick before
       // the next tick
-      // replaced process.nextTick with setImmediate,
-      // before there were still 2 clients connected after the tick, is this fix wrong ?
       setImmediate(function () {
         t.equal(broker.connectedClients, 1, 'one connected clients')
       })

--- a/test/will.js
+++ b/test/will.js
@@ -305,17 +305,18 @@ test('does not deliver will if keepalive is triggered during authentication', fu
 
 // [MQTT-3.14.4-1]
 test('does not deliver will when client sends a DISCONNECT', function (t) {
+  t.plan(0)
+
   var broker = aedes()
-  var s = willConnect(setup(broker), {},
-    function () {
-      s.inStream.end({
-        cmd: 'disconnect'
-      })
-    }
-  )
+  var s = willConnect(setup(broker), {}, function () {
+    s.inStream.end({
+      cmd: 'disconnect'
+    })
+  })
 
   s.broker.mq.on('mywill', function (packet, cb) {
     t.fail(packet)
   })
+
   broker.on('closed', t.end.bind(t))
 })


### PR DESCRIPTION
Hey,
I'm using this project very often and i noticed that having a nice ipAddress property might be useful for me and other users ( to use in preConnect hook for example ).
Since it's important to have a correct information, i thought it would be interesting to add a trustProxy property to the broker. Then if aedes is placed behind load balancer / proxy,  we could use http headers (x-real-ip / x-forwarded-for ) in case of websocket connection or proxy protocol in case of tcp socket.
So i implemented proxy-protocol-js to test incoming client's buffer and to try retrieving source ip address.

I've been adding an example and some tests.

Please let me know if this feature is useful and not out of the scope of aedes.
